### PR TITLE
Return CompletableFuture instead of Publisher in HttpHandler

### DIFF
--- a/src/main/java/org/springframework/reactive/web/dispatch/HandlerAdapter.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/HandlerAdapter.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.reactive.web.dispatch;
 
-import org.reactivestreams.Publisher;
+import java.util.concurrent.CompletableFuture;
 
 import org.springframework.reactive.web.http.ServerHttpRequest;
 import org.springframework.reactive.web.http.ServerHttpResponse;
@@ -27,6 +27,6 @@ public interface HandlerAdapter {
 
 	boolean supports(Object handler);
 
-	Publisher<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response, Object handler);
+	CompletableFuture<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response, Object handler);
 
 }

--- a/src/main/java/org/springframework/reactive/web/dispatch/HandlerResultHandler.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/HandlerResultHandler.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.reactive.web.dispatch;
 
-import org.reactivestreams.Publisher;
+import java.util.concurrent.CompletableFuture;
 
 import org.springframework.reactive.web.http.ServerHttpRequest;
 import org.springframework.reactive.web.http.ServerHttpResponse;
@@ -27,6 +27,6 @@ public interface HandlerResultHandler {
 
 	boolean supports(HandlerResult result);
 
-	Publisher<Void> handleResult(ServerHttpRequest request, ServerHttpResponse response, HandlerResult result);
+	CompletableFuture<Void> handleResult(ServerHttpRequest request, ServerHttpResponse response, HandlerResult result);
 
 }

--- a/src/main/java/org/springframework/reactive/web/dispatch/handler/HttpHandlerAdapter.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/handler/HttpHandlerAdapter.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.reactive.web.dispatch.handler;
 
-import org.reactivestreams.Publisher;
-import reactor.rx.Streams;
+import java.util.concurrent.CompletableFuture;
 
 import org.springframework.reactive.web.dispatch.HandlerAdapter;
 import org.springframework.reactive.web.dispatch.HandlerResult;
@@ -44,10 +43,10 @@ public class HttpHandlerAdapter implements HandlerAdapter {
 	}
 
 	@Override
-	public Publisher<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response, Object handler) {
+	public CompletableFuture<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response, Object handler) {
 		HttpHandler httpHandler = (HttpHandler) handler;
-		Publisher<Void> publisher = httpHandler.handle(request, response);
-		return Streams.wrap(publisher).map(aVoid -> null);
+		CompletableFuture<Void> handling = httpHandler.handle(request, response);
+		return handling.thenApply(aVoid -> null);
 	}
 
 }

--- a/src/main/java/org/springframework/reactive/web/dispatch/method/annotation/RequestMappingHandlerAdapter.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/method/annotation/RequestMappingHandlerAdapter.java
@@ -18,9 +18,7 @@ package org.springframework.reactive.web.dispatch.method.annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import org.reactivestreams.Publisher;
-import reactor.rx.Streams;
+import java.util.concurrent.CompletableFuture;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.reactive.codec.decoder.JacksonJsonDecoder;
@@ -64,7 +62,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Initializin
 	}
 
 	@Override
-	public Publisher<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response,
+	public CompletableFuture<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response,
 			Object handler) {
 
 		final InvocableHandlerMethod invocable = new InvocableHandlerMethod((HandlerMethod) handler);
@@ -75,10 +73,12 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Initializin
 			result = invocable.invokeForRequest(request);
 		}
 		catch (Exception ex) {
-			return Streams.fail(ex);
+			CompletableFuture<HandlerResult> exceptionFuture = new CompletableFuture<>();
+			exceptionFuture.completeExceptionally(ex);
+			return exceptionFuture;
 		}
 
-		return Streams.just(new HandlerResult(invocable, result));
+		return CompletableFuture.completedFuture(new HandlerResult(invocable, result));
 	}
 
 }

--- a/src/main/java/org/springframework/reactive/web/http/HttpHandler.java
+++ b/src/main/java/org/springframework/reactive/web/http/HttpHandler.java
@@ -16,15 +16,27 @@
 
 package org.springframework.reactive.web.http;
 
-import org.reactivestreams.Publisher;
+import java.util.concurrent.CompletableFuture;
 
 
 /**
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  */
 public interface HttpHandler {
 
-	Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response);
+	/**
+	 * Process the given HTTP request, generating a response.
+	 *
+	 * <p>Implementations should not throw exception but rather returns a future that
+	 * completes exceptionally.
+	 *
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @return a {@link CompletableFuture} that completes (as a success or an Exception
+	 * when the request processing is finished.
+	 */
+	CompletableFuture<Void> handle(ServerHttpRequest request, ServerHttpResponse response);
 
 }

--- a/src/main/java/org/springframework/reactive/web/http/ServerHttpResponse.java
+++ b/src/main/java/org/springframework/reactive/web/http/ServerHttpResponse.java
@@ -16,6 +16,7 @@
 package org.springframework.reactive.web.http;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 
 import org.reactivestreams.Publisher;
 
@@ -28,6 +29,6 @@ public interface ServerHttpResponse extends HttpMessage {
 
 	void setStatusCode(HttpStatus status);
 
-	Publisher<Void> writeWith(Publisher<ByteBuffer> contentPublisher);
+	CompletableFuture<Void> writeWith(Publisher<ByteBuffer> contentPublisher);
 
 }

--- a/src/main/java/org/springframework/reactive/web/http/rxnetty/RequestHandlerAdapter.java
+++ b/src/main/java/org/springframework/reactive/web/http/rxnetty/RequestHandlerAdapter.java
@@ -15,14 +15,15 @@
  */
 package org.springframework.reactive.web.http.rxnetty;
 
+import java.util.concurrent.CompletableFuture;
+
 import io.netty.buffer.ByteBuf;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
 import io.reactivex.netty.protocol.http.server.RequestHandler;
-import org.reactivestreams.Publisher;
 import rx.Observable;
-import rx.RxReactiveStreams;
 
+import org.springframework.reactive.util.CompletableFutureUtils;
 import org.springframework.reactive.web.http.HttpHandler;
 import org.springframework.util.Assert;
 
@@ -43,8 +44,8 @@ public class RequestHandlerAdapter implements RequestHandler<ByteBuf, ByteBuf> {
 	public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
 		RxNettyServerHttpRequest adaptedRequest = new RxNettyServerHttpRequest(request);
 		RxNettyServerHttpResponse adaptedResponse = new RxNettyServerHttpResponse(response);
-		Publisher<Void> result = this.httpHandler.handle(adaptedRequest, adaptedResponse);
-		return RxReactiveStreams.toObservable(result);
+		CompletableFuture<Void> result = this.httpHandler.handle(adaptedRequest, adaptedResponse);
+		return CompletableFutureUtils.toObservable(result);
 	}
 
 }

--- a/src/main/java/org/springframework/reactive/web/http/servlet/ServletServerHttpResponse.java
+++ b/src/main/java/org/springframework/reactive/web/http/servlet/ServletServerHttpResponse.java
@@ -18,6 +18,7 @@ package org.springframework.reactive.web.http.servlet;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -25,6 +26,7 @@ import org.reactivestreams.Publisher;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.reactive.util.CompletableFutureUtils;
 import org.springframework.reactive.web.http.ServerHttpResponse;
 import org.springframework.util.Assert;
 
@@ -62,9 +64,9 @@ public class ServletServerHttpResponse implements ServerHttpResponse {
 	}
 
 	@Override
-	public Publisher<Void> writeWith(final Publisher<ByteBuffer> contentPublisher) {
+	public CompletableFuture<Void> writeWith(final Publisher<ByteBuffer> contentPublisher) {
 		writeHeaders();
-		return (s -> contentPublisher.subscribe(responseSubscriber));
+		return CompletableFutureUtils.fromPublisher(s -> contentPublisher.subscribe(responseSubscriber)).thenApply(aVoid -> null);
 	}
 
 	private void writeHeaders() {

--- a/src/test/java/org/springframework/reactive/web/dispatch/handler/SimpleUrlHandlerMappingIntegrationTests.java
+++ b/src/test/java/org/springframework/reactive/web/dispatch/handler/SimpleUrlHandlerMappingIntegrationTests.java
@@ -19,9 +19,9 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.Test;
-import org.reactivestreams.Publisher;
 import reactor.io.buffer.Buffer;
 import reactor.rx.Streams;
 
@@ -97,7 +97,7 @@ public class SimpleUrlHandlerMappingIntegrationTests extends AbstractHttpHandler
 	private static class FooHandler implements HttpHandler {
 
 		@Override
-		public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+		public CompletableFuture<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 			return response.writeWith(Streams.just(Buffer.wrap("foo").byteBuffer()));
 		}
 	}
@@ -105,7 +105,7 @@ public class SimpleUrlHandlerMappingIntegrationTests extends AbstractHttpHandler
 	private static class BarHandler implements HttpHandler {
 
 		@Override
-		public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+		public CompletableFuture<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 			return response.writeWith(Streams.just(Buffer.wrap("bar").byteBuffer()));
 		}
 	}

--- a/src/test/java/org/springframework/reactive/web/http/EchoHandler.java
+++ b/src/test/java/org/springframework/reactive/web/http/EchoHandler.java
@@ -16,7 +16,7 @@
 
 package org.springframework.reactive.web.http;
 
-import org.reactivestreams.Publisher;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author Arjen Poutsma
@@ -24,7 +24,7 @@ import org.reactivestreams.Publisher;
 public class EchoHandler implements HttpHandler {
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+	public CompletableFuture<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 		return response.writeWith(request.getBody());
 	}
 }

--- a/src/test/java/org/springframework/reactive/web/http/RandomHandler.java
+++ b/src/test/java/org/springframework/reactive/web/http/RandomHandler.java
@@ -18,10 +18,10 @@ package org.springframework.reactive.web.http;
 
 import java.nio.ByteBuffer;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.io.buffer.Buffer;
@@ -41,7 +41,7 @@ public class RandomHandler implements HttpHandler {
 	private final Random rnd = new Random();
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+	public CompletableFuture<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 
 		request.getBody().subscribe(new Subscriber<ByteBuffer>() {
 			private Subscription s;

--- a/src/test/java/org/springframework/reactive/web/http/XmlHandler.java
+++ b/src/test/java/org/springframework/reactive/web/http/XmlHandler.java
@@ -16,13 +16,13 @@
 
 package org.springframework.reactive.web.http;
 
+import java.util.concurrent.CompletableFuture;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.reactivestreams.Publisher;
 
 import org.springframework.http.MediaType;
 import org.springframework.reactive.io.BufferOutputStream;
@@ -40,7 +40,7 @@ public class XmlHandler implements HttpHandler {
 	private static final Log logger = LogFactory.getLog(XmlHandler.class);
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request,
+	public CompletableFuture<Void> handle(ServerHttpRequest request,
 			ServerHttpResponse response) {
 		try {
 			JAXBContext jaxbContext = JAXBContext.newInstance(XmlHandlerIntegrationTests.Person.class);


### PR DESCRIPTION
`HttpHandler#handle()` return value purpose is to indicate when the handler
execution is complete, or to return an exception, both asynchronously.
`CompletableFuture<Void>` is exactly designed for this use case, not need
of `Publisher` additional behaviors (subscription,  back-pressure).

This change also remove the need for unneeded `Publisher` -> Reactor `Stream`
wrapping.

Fixes issue #10 (more details in the issue comments).