### PR TITLE
Return HandlerResult instead of Publisher<HandlerResult> in HttpHandlerAdapter#handle()

### DIFF
--- a/src/main/java/org/springframework/reactive/web/dispatch/DispatcherHandler.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/DispatcherHandler.java
@@ -91,9 +91,9 @@ public class DispatcherHandler implements HttpHandler, ApplicationContextAware {
 		}
 
 		HandlerAdapter handlerAdapter = getHandlerAdapter(handler);
-		Publisher<HandlerResult> resultPublisher = handlerAdapter.handle(request, response, handler);
 
-		return Streams.wrap(resultPublisher).concatMap((HandlerResult result) -> {
+		try {
+			HandlerResult result = handlerAdapter.handle(request, response, handler);
 			for (HandlerResultHandler resultHandler : resultHandlers) {
 				if (resultHandler.supports(result)) {
 					return resultHandler.handleResult(request, response, result);
@@ -101,7 +101,11 @@ public class DispatcherHandler implements HttpHandler, ApplicationContextAware {
 			}
 			return Streams.fail(new IllegalStateException(
 					"No HandlerResultHandler for " + result.getValue()));
-		});
+		}
+		catch(Exception ex) {
+			return Streams.fail(ex);
+		}
+
 	}
 
 	protected Object getHandler(ServerHttpRequest request) {

--- a/src/main/java/org/springframework/reactive/web/dispatch/SimpleHandlerResultHandler.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/SimpleHandlerResultHandler.java
@@ -13,18 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.reactive.web.dispatch;
 
+import org.reactivestreams.Publisher;
+
+import org.springframework.core.Ordered;
 import org.springframework.reactive.web.http.ServerHttpRequest;
 import org.springframework.reactive.web.http.ServerHttpResponse;
 
 /**
- * @author Rossen Stoyanchev
+ * Supports {@link HandlerResult} with a {@code Publisher<Void>} value.
+ *
+ * @author Sebastien Deleuze
  */
-public interface HandlerAdapter {
+public class SimpleHandlerResultHandler implements Ordered, HandlerResultHandler {
 
-	boolean supports(Object handler);
+	private int order = Ordered.LOWEST_PRECEDENCE;
 
-	HandlerResult handle(ServerHttpRequest request, ServerHttpResponse response, Object handler) throws Exception;
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
 
+	@Override
+	public boolean supports(HandlerResult result) {
+		Object value = result.getValue();
+		return value != null && Publisher.class.isAssignableFrom(value.getClass());
+	}
+
+	@Override
+	public Publisher<Void> handleResult(ServerHttpRequest request, ServerHttpResponse response, HandlerResult result) {
+		return (Publisher<Void>)result.getValue();
+	}
 }

--- a/src/main/java/org/springframework/reactive/web/dispatch/handler/HttpHandlerAdapter.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/handler/HttpHandlerAdapter.java
@@ -16,7 +16,6 @@
 package org.springframework.reactive.web.dispatch.handler;
 
 import org.reactivestreams.Publisher;
-import reactor.rx.Streams;
 
 import org.springframework.reactive.web.dispatch.HandlerAdapter;
 import org.springframework.reactive.web.dispatch.HandlerResult;
@@ -34,6 +33,7 @@ import org.springframework.reactive.web.http.ServerHttpResponse;
  * handler mappings.
  *
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  */
 public class HttpHandlerAdapter implements HandlerAdapter {
 
@@ -44,10 +44,10 @@ public class HttpHandlerAdapter implements HandlerAdapter {
 	}
 
 	@Override
-	public Publisher<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response, Object handler) {
-		HttpHandler httpHandler = (HttpHandler) handler;
-		Publisher<Void> publisher = httpHandler.handle(request, response);
-		return Streams.wrap(publisher).map(aVoid -> null);
+	public HandlerResult handle(ServerHttpRequest request, ServerHttpResponse response, Object handler) {
+		HttpHandler httpHandler = (HttpHandler)handler;
+		Publisher<Void> completion = httpHandler.handle(request, response);
+		return new HandlerResult(httpHandler, completion);
 	}
 
 }

--- a/src/main/java/org/springframework/reactive/web/dispatch/method/annotation/RequestMappingHandlerAdapter.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/method/annotation/RequestMappingHandlerAdapter.java
@@ -19,9 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.reactivestreams.Publisher;
-import reactor.rx.Streams;
-
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.reactive.codec.decoder.JacksonJsonDecoder;
 import org.springframework.reactive.codec.decoder.JsonObjectDecoder;
@@ -64,21 +61,15 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Initializin
 	}
 
 	@Override
-	public Publisher<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response,
-			Object handler) {
+	public HandlerResult handle(ServerHttpRequest request, ServerHttpResponse response,
+			Object handler) throws Exception {
 
 		final InvocableHandlerMethod invocable = new InvocableHandlerMethod((HandlerMethod) handler);
 		invocable.setHandlerMethodArgumentResolvers(this.argumentResolvers);
 
-		Object result;
-		try {
-			result = invocable.invokeForRequest(request);
-		}
-		catch (Exception ex) {
-			return Streams.fail(ex);
-		}
+		Object result = invocable.invokeForRequest(request);
 
-		return Streams.just(new HandlerResult(invocable, result));
+		return new HandlerResult(invocable, result);
 	}
 
 }

--- a/src/test/java/org/springframework/reactive/web/dispatch/handler/SimpleUrlHandlerMappingIntegrationTests.java
+++ b/src/test/java/org/springframework/reactive/web/dispatch/handler/SimpleUrlHandlerMappingIntegrationTests.java
@@ -28,6 +28,7 @@ import reactor.rx.Streams;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.reactive.web.dispatch.DispatcherHandler;
+import org.springframework.reactive.web.dispatch.SimpleHandlerResultHandler;
 import org.springframework.reactive.web.http.AbstractHttpHandlerIntegrationTests;
 import org.springframework.reactive.web.http.HttpHandler;
 import org.springframework.reactive.web.http.ServerHttpRequest;
@@ -52,6 +53,7 @@ public class SimpleUrlHandlerMappingIntegrationTests extends AbstractHttpHandler
 		StaticWebApplicationContext wac = new StaticWebApplicationContext();
 		wac.registerSingleton("hm", TestHandlerMapping.class);
 		wac.registerSingleton("ha", HttpHandlerAdapter.class);
+		wac.registerSingleton("hhrh", SimpleHandlerResultHandler.class);
 		wac.refresh();
 
 		DispatcherHandler dispatcherHandler = new DispatcherHandler();

--- a/src/test/java/org/springframework/reactive/web/dispatch/method/annotation/ResponseBodyResultHandlerTests.java
+++ b/src/test/java/org/springframework/reactive/web/dispatch/method/annotation/ResponseBodyResultHandlerTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.reactive.web.dispatch.method.annotation;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import org.springframework.reactive.web.dispatch.HandlerResult;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class ResponseBodyResultHandlerTests {
+
+	@Test
+	public void support() throws NoSuchMethodException {
+		ResponseBodyResultHandler resultHandler = new ResponseBodyResultHandler(Collections.emptyList());
+		TestController controller = new TestController();
+
+		HandlerMethod notAnnotatedMethod = new HandlerMethod(controller, TestController.class.getMethod("notAnnotated"));
+		assertFalse(resultHandler.supports(new HandlerResult(notAnnotatedMethod, null)));
+
+		HandlerMethod publisherStringMethod = new HandlerMethod(controller, TestController.class.getMethod("publisherString"));
+		assertTrue(resultHandler.supports(new HandlerResult(publisherStringMethod, null)));
+
+		HandlerMethod publisherVoidMethod = new HandlerMethod(controller, TestController.class.getMethod("publisherVoid"));
+		assertFalse(resultHandler.supports(new HandlerResult(publisherVoidMethod, null)));
+	}
+
+
+	private static class TestController {
+
+		public Publisher<String> notAnnotated() {
+			return null;
+		}
+
+		@ResponseBody
+		public Publisher<String> publisherString() {
+			return null;
+		}
+
+		@ResponseBody
+		public Publisher<Void> publisherVoid() {
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
As discussed during the meeting, this PR changes `HttpHandlerAdapter#handle()` from returning `Publisher<HandlerResult>` to `HandlerResult`.

This change implies another one from my POV: for non `@ResponseBody` based `HttpHandler`, the handling has been moved from `HttpHandlerAdapter` to an `HandlerResultHandler` implementation (the new `HttpHandlerResultHandler` class). That seems to me a logical change: performing the request is a `HandlerResultHandler`responsibility, not a `HttpHandlerAdapter` responsibility, for all implementations.
