### PR TITLE
Add a ResolvableType field to HandlerResult

### DIFF
--- a/src/main/java/org/springframework/reactive/web/dispatch/HandlerResult.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/HandlerResult.java
@@ -16,6 +16,7 @@
 
 package org.springframework.reactive.web.dispatch;
 
+import org.springframework.core.ResolvableType;
 
 /**
  * Represent the result of the invocation of an handler.
@@ -28,10 +29,13 @@ public class HandlerResult {
 
 	private final Object value;
 
+	private final ResolvableType type;
 
-	public HandlerResult(Object handler, Object value) {
+
+	public HandlerResult(Object handler, Object value, ResolvableType type) {
 		this.handler = handler;
 		this.value = value;
+		this.type = type;
 	}
 
 
@@ -43,4 +47,7 @@ public class HandlerResult {
 		return this.value;
 	}
 
+	public ResolvableType getType() {
+		return type;
+	}
 }

--- a/src/main/java/org/springframework/reactive/web/dispatch/SimpleHandlerResultHandler.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/SimpleHandlerResultHandler.java
@@ -22,6 +22,7 @@ import org.reactivestreams.Publisher;
 import reactor.Publishers;
 
 import org.springframework.core.Ordered;
+import org.springframework.core.ResolvableType;
 import org.springframework.http.server.ReactiveServerHttpRequest;
 import org.springframework.http.server.ReactiveServerHttpResponse;
 
@@ -31,6 +32,8 @@ import org.springframework.http.server.ReactiveServerHttpResponse;
  * @author Sebastien Deleuze
  */
 public class SimpleHandlerResultHandler implements Ordered, HandlerResultHandler {
+
+	private static final ResolvableType PUBLISHER_VOID = ResolvableType.forClassWithGenerics(Publisher.class, Void.class);
 
 	private int order = Ordered.LOWEST_PRECEDENCE;
 
@@ -46,8 +49,8 @@ public class SimpleHandlerResultHandler implements Ordered, HandlerResultHandler
 
 	@Override
 	public boolean supports(HandlerResult result) {
-		Object value = result.getValue();
-		return value != null && Publisher.class.isAssignableFrom(value.getClass());
+		ResolvableType type = result.getType();
+		return type != null && PUBLISHER_VOID.isAssignableFrom(type);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/reactive/web/dispatch/handler/HttpHandlerAdapter.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/handler/HttpHandlerAdapter.java
@@ -19,6 +19,7 @@ package org.springframework.reactive.web.dispatch.handler;
 import org.reactivestreams.Publisher;
 import reactor.Publishers;
 
+import org.springframework.core.ResolvableType;
 import org.springframework.http.server.ReactiveServerHttpRequest;
 import org.springframework.http.server.ReactiveServerHttpResponse;
 import org.springframework.reactive.web.dispatch.HandlerAdapter;
@@ -38,6 +39,8 @@ import org.springframework.reactive.web.http.HttpHandler;
  */
 public class HttpHandlerAdapter implements HandlerAdapter {
 
+	private static final ResolvableType PUBLISHER_VOID = ResolvableType.forClassWithGenerics(Publisher.class, Void.class);
+
 
 	@Override
 	public boolean supports(Object handler) {
@@ -50,7 +53,7 @@ public class HttpHandlerAdapter implements HandlerAdapter {
 
 		HttpHandler httpHandler = (HttpHandler)handler;
 		Publisher<Void> completion = httpHandler.handle(request, response);
-		return Publishers.just(new HandlerResult(httpHandler, completion));
+		return Publishers.just(new HandlerResult(httpHandler, completion, PUBLISHER_VOID));
 	}
 
 }

--- a/src/main/java/org/springframework/reactive/web/dispatch/method/annotation/RequestMappingHandlerAdapter.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/method/annotation/RequestMappingHandlerAdapter.java
@@ -24,6 +24,7 @@ import org.reactivestreams.Publisher;
 import reactor.Publishers;
 
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.server.ReactiveServerHttpRequest;
 import org.springframework.http.server.ReactiveServerHttpResponse;
@@ -90,9 +91,10 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Initializin
 
 		InvocableHandlerMethod handlerMethod = new InvocableHandlerMethod((HandlerMethod) handler);
 		handlerMethod.setHandlerMethodArgumentResolvers(this.argumentResolvers);
+		ResolvableType type =  ResolvableType.forMethodParameter(handlerMethod.getReturnType());
 
 		Publisher<Object> resultPublisher = handlerMethod.invokeForRequest(request);
-		return Publishers.map(resultPublisher, result -> new HandlerResult(handlerMethod, result));
+		return Publishers.map(resultPublisher, result -> new HandlerResult(handlerMethod, result, type));
 	}
 
 }

--- a/src/main/java/org/springframework/reactive/web/dispatch/method/annotation/ResponseBodyResultHandler.java
+++ b/src/main/java/org/springframework/reactive/web/dispatch/method/annotation/ResponseBodyResultHandler.java
@@ -101,14 +101,11 @@ public class ResponseBodyResultHandler implements HandlerResultHandler, Ordered 
 			ReactiveServerHttpResponse response, HandlerResult result) {
 
 		Object value = result.getValue();
-		HandlerMethod handlerMethod = (HandlerMethod) result.getHandler();
-		MethodParameter returnType = handlerMethod.getReturnValueType(value);
-
 		if (value == null) {
 			return Publishers.empty();
 		}
 
-		ResolvableType type = ResolvableType.forMethodParameter(returnType);
+		ResolvableType type = result.getType();
 		MediaType mediaType = resolveMediaType(request);
 		List<Object> hints = new ArrayList<>();
 		hints.add(UTF_8);
@@ -136,8 +133,7 @@ public class ResponseBodyResultHandler implements HandlerResultHandler, Ordered 
 			response.getHeaders().setContentType(mediaType);
 			return response.setBody(outputStream);
 		}
-		String returnTypeName = returnType.getParameterType().getName();
-		return Publishers.error(new IllegalStateException("Return value type '" + returnTypeName +
+		return Publishers.error(new IllegalStateException("Return value type '" + type +
 				"' with media type '" + mediaType + "' not supported"));
 	}
 

--- a/src/test/java/org/springframework/reactive/web/dispatch/SimpleHandlerResultHandlerTests.java
+++ b/src/test/java/org/springframework/reactive/web/dispatch/SimpleHandlerResultHandlerTests.java
@@ -14,62 +14,52 @@
  * limitations under the License.
  */
 
-package org.springframework.reactive.web.dispatch.method.annotation;
+package org.springframework.reactive.web.dispatch;
 
-import java.util.Collections;
-
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 
 import org.springframework.core.ResolvableType;
-import org.springframework.core.convert.support.DefaultConversionService;
-import org.springframework.reactive.codec.encoder.StringEncoder;
-import org.springframework.reactive.web.dispatch.HandlerResult;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.method.HandlerMethod;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Sebastien Deleuze
  */
-public class ResponseBodyResultHandlerTests {
-
+public class SimpleHandlerResultHandlerTests {
 
 	@Test
 	public void supports() throws NoSuchMethodException {
-		ResponseBodyResultHandler handler = new ResponseBodyResultHandler(Collections.singletonList(
-				new StringEncoder()), new DefaultConversionService());
+
+		SimpleHandlerResultHandler resultHandler = new SimpleHandlerResultHandler();
 		TestController controller = new TestController();
 
-		HandlerMethod hm = new HandlerMethod(controller,TestController.class.getMethod("notAnnotated"));
+		HandlerMethod hm = new HandlerMethod(controller, TestController.class.getMethod("voidReturnValue"));
 		ResolvableType type = ResolvableType.forMethodParameter(hm.getReturnType());
-		assertFalse(handler.supports(new HandlerResult(hm, null, type)));
+		assertFalse(resultHandler.supports(new HandlerResult(hm, null, type)));
 
 		hm = new HandlerMethod(controller, TestController.class.getMethod("publisherString"));
 		type = ResolvableType.forMethodParameter(hm.getReturnType());
-		assertTrue(handler.supports(new HandlerResult(hm, null, type)));
+		assertFalse(resultHandler.supports(new HandlerResult(hm, null, type)));
 
 		hm = new HandlerMethod(controller, TestController.class.getMethod("publisherVoid"));
 		type = ResolvableType.forMethodParameter(hm.getReturnType());
-		assertTrue(handler.supports(new HandlerResult(hm, null, type)));
+		assertTrue(resultHandler.supports(new HandlerResult(hm, null, type)));
 	}
 
 
 	@SuppressWarnings("unused")
 	private static class TestController {
 
-		public Publisher<String> notAnnotated() {
+		public Publisher<String> voidReturnValue() {
 			return null;
 		}
 
-		@ResponseBody
 		public Publisher<String> publisherString() {
 			return null;
 		}
 
-		@ResponseBody
 		public Publisher<Void> publisherVoid() {
 			return null;
 		}


### PR DESCRIPTION
This change allows to be able to check generic type on the return value
at HandlerAdapter and ResultHandler level. For example, it allows to do
a Publisher<Void> check in SimpleHandlerResultHandler.

This change is related to [this discussion](https://github.com/spring-projects/spring-reactive/commit/b8a62e93d9dc99a0a0113ae80da53b9b7e006041).

Are you ok with these changes @rstoyanchev?