### PR TITLE
Use Bytes abstraction instead of java.nio.ByteBuffer

### DIFF
--- a/src/main/java/org/springframework/core/codec/Decoder.java
+++ b/src/main/java/org/springframework/core/codec/Decoder.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.reactivestreams.Publisher;
 
 import org.springframework.core.ResolvableType;
-import org.springframework.core.codec.Encoder;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 
 /**
@@ -50,7 +50,7 @@ public interface Decoder<T> {
 	 * @param hints Additional information about how to do decode, optional.
 	 * @return the output stream
 	 */
-	Publisher<T> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	Publisher<T> decode(Publisher<Bytes> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints);
 
 	/**

--- a/src/main/java/org/springframework/core/codec/Encoder.java
+++ b/src/main/java/org/springframework/core/codec/Encoder.java
@@ -16,12 +16,12 @@
 
 package org.springframework.core.codec;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.reactivestreams.Publisher;
 
 import org.springframework.core.ResolvableType;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 
 /**
@@ -42,14 +42,14 @@ public interface Encoder<T> {
 	boolean canEncode(ResolvableType type, MimeType mimeType, Object... hints);
 
 	/**
-	 * Encode an input stream of {@code T} to an output {@link ByteBuffer} stream.
+	 * Encode an input stream of {@code T} to an output {@link Bytes} stream.
 	 * @param inputStream the input stream to process.
 	 * @param type the stream element type to process.
 	 * @param mimeType the mime type to process.
 	 * @param hints Additional information about how to do decode, optional.
 	 * @return the output stream
 	 */
-	Publisher<ByteBuffer> encode(Publisher<? extends T> inputStream, ResolvableType type,
+	Publisher<Bytes> encode(Publisher<? extends T> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints);
 
 	/**

--- a/src/main/java/org/springframework/core/codec/support/BytesDecoder.java
+++ b/src/main/java/org/springframework/core/codec/support/BytesDecoder.java
@@ -21,16 +21,16 @@ import java.nio.ByteBuffer;
 import org.reactivestreams.Publisher;
 
 import org.springframework.core.ResolvableType;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 
 /**
  * @author Sebastien Deleuze
  */
-public class ByteBufferDecoder extends AbstractDecoder<ByteBuffer> {
+public class BytesDecoder extends AbstractDecoder<Bytes> {
 
-
-	public ByteBufferDecoder() {
+	public BytesDecoder() {
 		super(MimeTypeUtils.ALL);
 	}
 
@@ -42,7 +42,7 @@ public class ByteBufferDecoder extends AbstractDecoder<ByteBuffer> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Publisher<Bytes> decode(Publisher<Bytes> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		return inputStream;

--- a/src/main/java/org/springframework/core/codec/support/BytesEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/BytesEncoder.java
@@ -16,21 +16,19 @@
 
 package org.springframework.core.codec.support;
 
-import java.nio.ByteBuffer;
-
 import org.reactivestreams.Publisher;
 
 import org.springframework.core.ResolvableType;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 
 /**
  * @author Sebastien Deleuze
  */
-public class ByteBufferEncoder extends AbstractEncoder<ByteBuffer> {
+public class BytesEncoder extends AbstractEncoder<Bytes> {
 
-
-	public ByteBufferEncoder() {
+	public BytesEncoder() {
 		super(MimeTypeUtils.ALL);
 	}
 
@@ -38,15 +36,15 @@ public class ByteBufferEncoder extends AbstractEncoder<ByteBuffer> {
 	@Override
 	public boolean canEncode(ResolvableType type, MimeType mimeType, Object... hints) {
 		Class<?> clazz = type.getRawClass();
-		return (super.canEncode(type, mimeType, hints) && ByteBuffer.class.isAssignableFrom(clazz));
+		return (super.canEncode(type, mimeType, hints) && Bytes.class.isAssignableFrom(clazz));
 	}
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends ByteBuffer> inputStream, ResolvableType type,
+	public Publisher<Bytes> encode(Publisher<? extends Bytes> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		//noinspection unchecked
-		return (Publisher<ByteBuffer>) inputStream;
+		return (Publisher<Bytes>) inputStream;
 	}
 
 }

--- a/src/main/java/org/springframework/core/codec/support/JacksonJsonDecoder.java
+++ b/src/main/java/org/springframework/core/codec/support/JacksonJsonDecoder.java
@@ -17,7 +17,6 @@
 package org.springframework.core.codec.support;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,7 +27,8 @@ import reactor.Publishers;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.CodecException;
 import org.springframework.core.codec.Decoder;
-import org.springframework.util.ByteBufferInputStream;
+import org.springframework.util.BytesInputStream;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 
 
@@ -42,18 +42,18 @@ public class JacksonJsonDecoder extends AbstractDecoder<Object> {
 
 	private final ObjectMapper mapper;
 
-	private Decoder<ByteBuffer> preProcessor;
+	private Decoder<Bytes> preProcessor;
 
 
 	public JacksonJsonDecoder() {
 		this(new ObjectMapper(), null);
 	}
 
-	public JacksonJsonDecoder(Decoder<ByteBuffer> preProcessor) {
+	public JacksonJsonDecoder(Decoder<Bytes> preProcessor) {
 		this(new ObjectMapper(), preProcessor);
 	}
 
-	public JacksonJsonDecoder(ObjectMapper mapper, Decoder<ByteBuffer> preProcessor) {
+	public JacksonJsonDecoder(ObjectMapper mapper, Decoder<Bytes> preProcessor) {
 		super(new MimeType("application", "json", StandardCharsets.UTF_8),
 				new MimeType("application", "*+json", StandardCharsets.UTF_8));
 		this.mapper = mapper;
@@ -62,7 +62,7 @@ public class JacksonJsonDecoder extends AbstractDecoder<Object> {
 
 
 	@Override
-	public Publisher<Object> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Publisher<Object> decode(Publisher<Bytes> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		ObjectReader reader = this.mapper.readerFor(type.getRawClass());
@@ -73,7 +73,7 @@ public class JacksonJsonDecoder extends AbstractDecoder<Object> {
 
 		return Publishers.map(inputStream, content -> {
 			try {
-				return reader.readValue(new ByteBufferInputStream(content));
+				return reader.readValue(new BytesInputStream(content));
 			}
 			catch (IOException e) {
 				throw new CodecException("Error while reading the data", e);

--- a/src/main/java/org/springframework/core/codec/support/JacksonJsonEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/JacksonJsonEncoder.java
@@ -17,7 +17,6 @@
 package org.springframework.core.codec.support;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +28,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.CodecException;
 import org.springframework.core.codec.Encoder;
 import org.springframework.util.BufferOutputStream;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 
 /**
@@ -41,19 +41,18 @@ public class JacksonJsonEncoder extends AbstractEncoder<Object> {
 
 	private final ObjectMapper mapper;
 
-	private Encoder<ByteBuffer> postProcessor;
+	private Encoder<Bytes> postProcessor;
 
 
 	public JacksonJsonEncoder() {
 		this(new ObjectMapper(), null);
 	}
 
-	public JacksonJsonEncoder(Encoder<ByteBuffer> postProcessor) {
+	public JacksonJsonEncoder(Encoder<Bytes> postProcessor) {
 		this(new ObjectMapper(), postProcessor);
 	}
 
-
-	public JacksonJsonEncoder(ObjectMapper mapper, Encoder<ByteBuffer> postProcessor) {
+	public JacksonJsonEncoder(ObjectMapper mapper, Encoder<Bytes> postProcessor) {
 		super(new MimeType("application", "json", StandardCharsets.UTF_8),
 				new MimeType("application", "*+json", StandardCharsets.UTF_8));
 		this.mapper = mapper;
@@ -61,10 +60,10 @@ public class JacksonJsonEncoder extends AbstractEncoder<Object> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends Object> inputStream,
+	public Publisher<Bytes> encode(Publisher<? extends Object> inputStream,
 			ResolvableType type, MimeType mimeType, Object... hints) {
 
-		Publisher<ByteBuffer> stream = Publishers.map(inputStream, value -> {
+		Publisher<Bytes> stream = Publishers.map(inputStream, value -> {
 			Buffer buffer = new Buffer();
 			BufferOutputStream outputStream = new BufferOutputStream(buffer);
 			try {
@@ -74,7 +73,7 @@ public class JacksonJsonEncoder extends AbstractEncoder<Object> {
 				throw new CodecException("Error while writing the data", e);
 			}
 			buffer.flip();
-			return buffer.byteBuffer();
+			return Bytes.from(buffer.byteBuffer());
 		});
 		if (this.postProcessor != null) {
 			stream = this.postProcessor.encode(stream, type, mimeType, hints);

--- a/src/main/java/org/springframework/core/codec/support/Jaxb2Decoder.java
+++ b/src/main/java/org/springframework/core/codec/support/Jaxb2Decoder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.core.codec.support;
 
-import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.xml.bind.JAXBContext;
@@ -38,7 +37,8 @@ import reactor.Publishers;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.CodecException;
-import org.springframework.util.ByteBufferPublisherInputStream;
+import org.springframework.util.BytesPublisherInputStream;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
@@ -60,12 +60,12 @@ public class Jaxb2Decoder extends AbstractDecoder<Object> {
 
 
 	@Override
-	public Publisher<Object> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Publisher<Object> decode(Publisher<Bytes> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		Class<?> outputClass = type.getRawClass();
 		try {
-			Source source = processSource(new StreamSource(new ByteBufferPublisherInputStream(inputStream)));
+			Source source = processSource(new StreamSource(new BytesPublisherInputStream(inputStream)));
 			Unmarshaller unmarshaller = createUnmarshaller(outputClass);
 			if (outputClass.isAnnotationPresent(XmlRootElement.class)) {
 				return Publishers.just(unmarshaller.unmarshal(source));

--- a/src/main/java/org/springframework/core/codec/support/Jaxb2Encoder.java
+++ b/src/main/java/org/springframework/core/codec/support/Jaxb2Encoder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.core.codec.support;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -32,6 +31,7 @@ import reactor.io.buffer.Buffer;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.CodecException;
 import org.springframework.util.BufferOutputStream;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.MimeType;
@@ -54,7 +54,7 @@ public class Jaxb2Encoder extends AbstractEncoder<Object> {
 
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends Object> messageStream, ResolvableType type,
+	public Publisher<Bytes> encode(Publisher<? extends Object> messageStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		return Publishers.map(messageStream, value -> {
@@ -66,7 +66,7 @@ public class Jaxb2Encoder extends AbstractEncoder<Object> {
 				marshaller.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.name());
 				marshaller.marshal(value, outputStream);
 				buffer.flip();
-				return buffer.byteBuffer();
+				return Bytes.from(buffer.byteBuffer());
 			}
 			catch (MarshalException ex) {
 				throw new CodecException("Could not marshal [" + value + "]: " + ex.getMessage(), ex);

--- a/src/main/java/org/springframework/core/codec/support/JsonObjectDecoder.java
+++ b/src/main/java/org/springframework/core/codec/support/JsonObjectDecoder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.core.codec.support;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +28,7 @@ import reactor.Publishers;
 import reactor.fn.Function;
 
 import org.springframework.core.ResolvableType;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 
 /**
@@ -42,10 +42,12 @@ import org.springframework.util.MimeType;
  * Based on <a href=https://github.com/netty/netty/blob/master/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java">
  * Netty {@code JsonObjectDecoder}</a>
  *
+ * TODO Use {@link Bytes} instead of {@code ByteBuf}
+ *
  * @author Sebastien Deleuze
  * @see JsonObjectEncoder
  */
-public class JsonObjectDecoder extends AbstractDecoder<ByteBuffer> {
+public class JsonObjectDecoder extends AbstractDecoder<Bytes> {
 
 	private static final int ST_CORRUPTED = -1;
 
@@ -95,10 +97,10 @@ public class JsonObjectDecoder extends AbstractDecoder<ByteBuffer> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Publisher<Bytes> decode(Publisher<Bytes> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
-		return Publishers.flatMap(inputStream, new Function<ByteBuffer, Publisher<? extends ByteBuffer>>() {
+		return Publishers.flatMap(inputStream, new Function<Bytes, Publisher<? extends Bytes>>() {
 
 			int openBraces;
 			int index;
@@ -108,14 +110,14 @@ public class JsonObjectDecoder extends AbstractDecoder<ByteBuffer> {
 			Integer writerIndex;
 
 			@Override
-			public Publisher<? extends ByteBuffer> apply(ByteBuffer b) {
-				List<ByteBuffer> chunks = new ArrayList<>();
+			public Publisher<? extends Bytes> apply(Bytes b) {
+				List<Bytes> chunks = new ArrayList<>();
 				if (this.input == null) {
-					this.input = Unpooled.copiedBuffer(b);
+					this.input = Unpooled.copiedBuffer(b.asBytes());
 					this.writerIndex = this.input.writerIndex();
 				}
 				else {
-					this.input = Unpooled.copiedBuffer(this.input, Unpooled.copiedBuffer(b));
+					this.input = Unpooled.copiedBuffer(this.input, Unpooled.copiedBuffer(b.asBytes()));
 					this.writerIndex = this.input.writerIndex();
 				}
 				if (this.state == ST_CORRUPTED) {
@@ -140,7 +142,7 @@ public class JsonObjectDecoder extends AbstractDecoder<ByteBuffer> {
 							ByteBuf json = extractObject(this.input, this.input.readerIndex(),
 									this.index + 1 - this.input.readerIndex());
 							if (json != null) {
-								chunks.add(json.nioBuffer());
+								chunks.add(Bytes.from(json.nioBuffer()));
 							}
 
 							// The JSON object/array was extracted => discard the bytes from
@@ -174,7 +176,7 @@ public class JsonObjectDecoder extends AbstractDecoder<ByteBuffer> {
 									idxNoSpaces + 1 - this.input.readerIndex());
 
 							if (json != null) {
-								chunks.add(json.nioBuffer());
+								chunks.add(Bytes.from(json.nioBuffer()));
 							}
 
 							this.input.readerIndex(this.index + 1);

--- a/src/main/java/org/springframework/core/codec/support/JsonObjectEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/JsonObjectEncoder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.core.codec.support;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -25,9 +24,9 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.subscriber.SubscriberBarrier;
 import reactor.core.support.BackpressureUtils;
-import reactor.io.buffer.Buffer;
 
 import org.springframework.core.ResolvableType;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 
 import static reactor.Publishers.lift;
@@ -41,7 +40,7 @@ import static reactor.Publishers.lift;
  *
  * @see JsonObjectDecoder
  */
-public class JsonObjectEncoder extends AbstractEncoder<ByteBuffer> {
+public class JsonObjectEncoder extends AbstractEncoder<Bytes> {
 
 	public JsonObjectEncoder() {
 		super(new MimeType("application", "json", StandardCharsets.UTF_8),
@@ -49,7 +48,7 @@ public class JsonObjectEncoder extends AbstractEncoder<ByteBuffer> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends ByteBuffer> messageStream,
+	public Publisher<Bytes> encode(Publisher<? extends Bytes> messageStream,
 			ResolvableType type, MimeType mimeType, Object... hints) {
 
 		//noinspection Convert2MethodRef
@@ -57,7 +56,7 @@ public class JsonObjectEncoder extends AbstractEncoder<ByteBuffer> {
 	}
 
 
-	private static class JsonEncoderBarrier extends SubscriberBarrier<ByteBuffer, ByteBuffer> {
+	private static class JsonEncoderBarrier extends SubscriberBarrier<Bytes, Bytes> {
 
 		@SuppressWarnings("rawtypes")
 		static final AtomicLongFieldUpdater<JsonEncoderBarrier> REQUESTED =
@@ -67,7 +66,7 @@ public class JsonObjectEncoder extends AbstractEncoder<ByteBuffer> {
 				AtomicIntegerFieldUpdater.newUpdater(JsonEncoderBarrier.class, "terminated");
 
 
-		private ByteBuffer prev = null;
+		private Bytes prev = null;
 
 		private long count = 0;
 
@@ -76,7 +75,7 @@ public class JsonObjectEncoder extends AbstractEncoder<ByteBuffer> {
 		private volatile int terminated;
 
 
-		public JsonEncoderBarrier(Subscriber<? super ByteBuffer> subscriber) {
+		public JsonEncoderBarrier(Subscriber<? super Bytes> subscriber) {
 			super(subscriber);
 		}
 
@@ -93,7 +92,7 @@ public class JsonObjectEncoder extends AbstractEncoder<ByteBuffer> {
 		}
 
 		@Override
-		protected void doNext(ByteBuffer next) {
+		protected void doNext(Bytes next) {
 			this.count++;
 			if (this.count == 1) {
 				this.prev = next;
@@ -101,29 +100,29 @@ public class JsonObjectEncoder extends AbstractEncoder<ByteBuffer> {
 				return;
 			}
 
-			ByteBuffer tmp = this.prev;
+			Bytes tmp = this.prev;
 			this.prev = next;
-			Buffer buffer = new Buffer();
+			Bytes buffer = Bytes.create();
 			if (this.count == 2) {
-				buffer.append("[");
+				buffer.append("[".getBytes());
 			}
 			buffer.append(tmp);
-			buffer.append(",");
+			buffer.append(",".getBytes());
 			buffer.flip();
 
 			BackpressureUtils.getAndSub(REQUESTED, this, 1L);
-			downstream().onNext(buffer.byteBuffer());
+			downstream().onNext(buffer);
 		}
 
 		protected void drainLast(){
 			if(BackpressureUtils.getAndSub(REQUESTED, this, 1L) > 0) {
-				Buffer buffer = new Buffer();
+				Bytes buffer = Bytes.create();
 				buffer.append(this.prev);
 				if (this.count > 1) {
-					buffer.append("]");
+					buffer.append("]".getBytes());
 				}
 				buffer.flip();
-				downstream().onNext(buffer.byteBuffer());
+				downstream().onNext(buffer);
 				super.doComplete();
 			}
 		}

--- a/src/main/java/org/springframework/core/codec/support/StringDecoder.java
+++ b/src/main/java/org/springframework/core/codec/support/StringDecoder.java
@@ -16,15 +16,14 @@
 
 package org.springframework.core.codec.support;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.reactivestreams.Publisher;
 import reactor.Publishers;
-import reactor.io.buffer.Buffer;
 
 import org.springframework.core.ResolvableType;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 
 /**
@@ -48,7 +47,7 @@ public class StringDecoder extends AbstractDecoder<String> {
 	}
 
 	@Override
-	public Publisher<String> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Publisher<String> decode(Publisher<Bytes> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		Charset charset;
@@ -58,7 +57,7 @@ public class StringDecoder extends AbstractDecoder<String> {
 		else {
 			 charset = DEFAULT_CHARSET;
 		}
-		return Publishers.map(inputStream, content -> new String(new Buffer(content).asBytes(), charset));
+		return Publishers.map(inputStream, content -> new String(content.asBytes(), charset));
 	}
 
 }

--- a/src/main/java/org/springframework/core/codec/support/StringEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/StringEncoder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.core.codec.support;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -24,6 +23,7 @@ import org.reactivestreams.Publisher;
 import reactor.Publishers;
 
 import org.springframework.core.ResolvableType;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.MimeType;
 
 /**
@@ -49,7 +49,7 @@ public class StringEncoder extends AbstractEncoder<String> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends String> elementStream,
+	public Publisher<Bytes> encode(Publisher<? extends String> elementStream,
 			ResolvableType type, MimeType mimeType, Object... hints) {
 
 		Charset charset;
@@ -59,7 +59,7 @@ public class StringEncoder extends AbstractEncoder<String> {
 		else {
 			 charset = DEFAULT_CHARSET;
 		}
-		return Publishers.map(elementStream, s -> ByteBuffer.wrap(s.getBytes(charset)));
+		return Publishers.map(elementStream, s -> Bytes.from(s.getBytes(charset)));
 	}
 
 }

--- a/src/main/java/org/springframework/core/io/Bytes.java
+++ b/src/main/java/org/springframework/core/io/Bytes.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.io;
+
+import java.nio.ByteBuffer;
+
+import org.springframework.core.io.support.ReactorBufferBackedBytes;
+
+/**
+ * WIP byte buffer interface
+ *
+ * @author Sebastien Deleuze
+ */
+public interface Bytes {
+
+	static Bytes create() {
+		return new ReactorBufferBackedBytes();
+	}
+
+	static Bytes from(ByteBuffer byteBuffer) {
+		return new ReactorBufferBackedBytes(byteBuffer);
+	}
+
+	static Bytes from(byte[] bytes) {
+		return new ReactorBufferBackedBytes(bytes);
+	}
+
+
+	int get();
+
+	void get(byte[] b);
+
+	void get(byte[] dst, int offset, int length);
+
+	byte[] asBytes();
+
+	ByteBuffer asByteBuffer();
+
+	boolean hasRemaining();
+
+	int remaining();
+
+	int limit();
+
+	Bytes append(byte[] bytes);
+
+	Bytes append(Bytes bytes);
+
+	// TODO Remove this horrible flip() method, manage reader + writer indexes to avoid this like in Netty ByteBuf
+	void flip();
+
+}

--- a/src/main/java/org/springframework/core/io/support/ReactorBufferBackedBytes.java
+++ b/src/main/java/org/springframework/core/io/support/ReactorBufferBackedBytes.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.io.support;
+
+import java.nio.ByteBuffer;
+
+import reactor.io.buffer.Buffer;
+
+import org.springframework.core.io.Bytes;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class ReactorBufferBackedBytes implements Bytes {
+
+	private final Buffer buffer;
+
+
+	public ReactorBufferBackedBytes() {
+		this.buffer = new Buffer();
+	}
+
+	public ReactorBufferBackedBytes(ByteBuffer byteBuffer) {
+		this.buffer = new Buffer(byteBuffer);
+	}
+
+	public ReactorBufferBackedBytes(byte[] bytes) {
+		this.buffer = Buffer.wrap(bytes);
+	}
+
+
+	@Override
+	public int get() {
+		return this.buffer.byteBuffer().get();
+	}
+
+	@Override
+	public void get(byte[] dst, int offset, int length) {
+		this.buffer.byteBuffer().get(dst, offset, length);
+	}
+
+	@Override
+	public void get(byte[] b) {
+		this.buffer.byteBuffer().get(b);
+	}
+
+	@Override
+	public byte[] asBytes() {
+		return this.buffer.asBytes();
+	}
+
+	@Override
+	public ByteBuffer asByteBuffer() {
+		return this.buffer.byteBuffer();
+	}
+
+	@Override
+	public boolean hasRemaining() {
+		return this.buffer.byteBuffer().hasRemaining();
+	}
+
+	@Override
+	public int remaining() {
+		return this.buffer.byteBuffer().remaining();
+	}
+
+	@Override
+	public int limit() {
+		return this.buffer.limit();
+	}
+
+	@Override
+	public Bytes append(byte[] bytes) {
+		this.buffer.append(bytes);
+		return this;
+	}
+
+	@Override
+	public Bytes append(Bytes bytes) {
+		this.append(bytes.asBytes());
+		return this;
+	}
+
+	@Override
+	public void flip() {
+		this.buffer.flip();
+	}
+
+}

--- a/src/main/java/org/springframework/http/ReactiveHttpInputMessage.java
+++ b/src/main/java/org/springframework/http/ReactiveHttpInputMessage.java
@@ -16,9 +16,9 @@
 
 package org.springframework.http;
 
-import java.nio.ByteBuffer;
-
 import org.reactivestreams.Publisher;
+
+import org.springframework.core.io.Bytes;
 
 /**
  * Represents a "reactive" HTTP input message, consisting of
@@ -36,6 +36,6 @@ public interface ReactiveHttpInputMessage extends HttpMessage {
 	 * Return the body of the message as an publisher of {@code ByteBuffer}s.
 	 * @return the body
 	 */
-	Publisher<ByteBuffer> getBody();
+	Publisher<Bytes> getBody();
 
 }

--- a/src/main/java/org/springframework/http/ReactiveHttpOutputMessage.java
+++ b/src/main/java/org/springframework/http/ReactiveHttpOutputMessage.java
@@ -20,6 +20,8 @@ import java.nio.ByteBuffer;
 
 import org.reactivestreams.Publisher;
 
+import org.springframework.core.io.Bytes;
+
 /**
  * Represents a "reactive" HTTP output message, consisting of
  * {@linkplain #getHeaders() headers} and the capability to add a
@@ -40,6 +42,6 @@ public interface ReactiveHttpOutputMessage extends HttpMessage {
 	 * @param body the body to use
 	 * @return a publisher that indicates completion
 	 */
-	Publisher<Void> setBody(Publisher<ByteBuffer> body);
+	Publisher<Void> setBody(Publisher<Bytes> body);
 
 }

--- a/src/main/java/org/springframework/http/server/reactor/PublisherReactorServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/reactor/PublisherReactorServerHttpRequest.java
@@ -17,7 +17,6 @@ package org.springframework.http.server.reactor;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 
 import org.reactivestreams.Publisher;
 import reactor.Publishers;
@@ -27,6 +26,7 @@ import reactor.io.net.http.HttpChannel;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.server.ReactiveServerHttpRequest;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 /**
@@ -74,8 +74,8 @@ public class PublisherReactorServerHttpRequest implements ReactiveServerHttpRequ
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
-		return Publishers.map(channel.input(), Buffer::byteBuffer);
+	public Publisher<Bytes> getBody() {
+		return Publishers.map(channel.input(), buffer -> Bytes.from(buffer.byteBuffer()));
 	}
 
 }

--- a/src/main/java/org/springframework/http/server/reactor/PublisherReactorServerHttpResponse.java
+++ b/src/main/java/org/springframework/http/server/reactor/PublisherReactorServerHttpResponse.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.http.server.reactor;
 
-import java.nio.ByteBuffer;
-
 import org.reactivestreams.Publisher;
 import reactor.Publishers;
 import reactor.io.buffer.Buffer;
@@ -26,6 +24,7 @@ import reactor.io.net.http.model.Status;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ReactiveServerHttpResponse;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 /**
@@ -67,9 +66,9 @@ public class PublisherReactorServerHttpResponse implements ReactiveServerHttpRes
 	}
 
 	@Override
-	public Publisher<Void> setBody(Publisher<ByteBuffer> contentPublisher) {
+	public Publisher<Void> setBody(Publisher<Bytes> contentPublisher) {
 		applyHeaders();
-		return this.channel.writeWith(Publishers.map(contentPublisher, Buffer::new));
+		return this.channel.writeWith(Publishers.map(contentPublisher, bytes -> new Buffer(bytes.asByteBuffer())));
 	}
 
 	private void applyHeaders() {

--- a/src/main/java/org/springframework/http/server/reactor/ReactorServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/reactor/ReactorServerHttpRequest.java
@@ -16,12 +16,12 @@
 
 package org.springframework.http.server.reactor;
 
-import java.nio.ByteBuffer;
-
 import reactor.io.buffer.Buffer;
 import reactor.io.net.http.HttpChannel;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
+
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Stephane Maldini
@@ -33,7 +33,7 @@ public class ReactorServerHttpRequest extends PublisherReactorServerHttpRequest 
 	}
 
 	@Override
-	public Stream<ByteBuffer> getBody() {
+	public Stream<Bytes> getBody() {
 		return Streams.wrap(super.getBody());
 	}
 

--- a/src/main/java/org/springframework/http/server/reactor/ReactorServerHttpResponse.java
+++ b/src/main/java/org/springframework/http/server/reactor/ReactorServerHttpResponse.java
@@ -16,13 +16,13 @@
 
 package org.springframework.http.server.reactor;
 
-import java.nio.ByteBuffer;
-
 import org.reactivestreams.Publisher;
 import reactor.io.buffer.Buffer;
 import reactor.io.net.http.HttpChannel;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
+
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Stephane Maldini
@@ -39,7 +39,7 @@ public class ReactorServerHttpResponse extends PublisherReactorServerHttpRespons
 	}
 
 	@Override
-	public Stream<Void> setBody(Publisher<ByteBuffer> contentPublisher) {
+	public Stream<Void> setBody(Publisher<Bytes> contentPublisher) {
 		return Streams.wrap(super.setBody(contentPublisher));
 	}
 }

--- a/src/main/java/org/springframework/http/server/rxnetty/RxNettyServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/rxnetty/RxNettyServerHttpRequest.java
@@ -18,7 +18,6 @@ package org.springframework.http.server.rxnetty;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 
 import io.netty.buffer.ByteBuf;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
@@ -29,6 +28,7 @@ import rx.Observable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.server.ReactiveServerHttpRequest;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 /**
@@ -78,12 +78,12 @@ public class RxNettyServerHttpRequest implements ReactiveServerHttpRequest {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
-		Observable<ByteBuffer> bytesContent = this.request.getContent().map(ByteBuf::nioBuffer);
+	public Publisher<Bytes> getBody() {
+		Observable<Bytes> bytesContent = this.request.getContent().map(byteBuf -> Bytes.from(byteBuf.nioBuffer()));
 		return RxJava1Converter.from(bytesContent);
 	}
 
-	public Observable<ByteBuffer> asObservable() {
-		return this.request.getContent().map(ByteBuf::nioBuffer);
+	public Observable<Bytes> asObservable() {
+		return this.request.getContent().map(byteBuf -> Bytes.from(byteBuf.nioBuffer()));
 	}
 }

--- a/src/main/java/org/springframework/http/server/rxnetty/RxNettyServerHttpResponse.java
+++ b/src/main/java/org/springframework/http/server/rxnetty/RxNettyServerHttpResponse.java
@@ -16,19 +16,17 @@
 
 package org.springframework.http.server.rxnetty;
 
-import java.nio.ByteBuffer;
-
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
 import org.reactivestreams.Publisher;
 import reactor.Publishers;
 import reactor.core.publisher.convert.RxJava1Converter;
-import reactor.io.buffer.Buffer;
 import rx.Observable;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ReactiveServerHttpResponse;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 /**
@@ -71,10 +69,10 @@ public class RxNettyServerHttpResponse implements ReactiveServerHttpResponse {
 	}
 
 	@Override
-	public Publisher<Void> setBody(Publisher<ByteBuffer> publisher) {
+	public Publisher<Void> setBody(Publisher<Bytes> publisher) {
 		applyHeaders();
 		Observable<byte[]> observable = RxJava1Converter.from(publisher).map(
-				content -> new Buffer(content).asBytes());
+				content -> content.asBytes());
 		return RxJava1Converter.from(this.response.writeBytes(observable));
 	}
 

--- a/src/main/java/org/springframework/http/server/servlet31/RequestBodyPublisher.java
+++ b/src/main/java/org/springframework/http/server/servlet31/RequestBodyPublisher.java
@@ -17,7 +17,6 @@
 package org.springframework.http.server.servlet31;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.servlet.ReadListener;
@@ -29,12 +28,13 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 /**
  * @author Arjen Poutsma
  */
-public class RequestBodyPublisher implements ReadListener, Publisher<ByteBuffer> {
+public class RequestBodyPublisher implements ReadListener, Publisher<Bytes> {
 
 	private static final Log logger = LogFactory.getLog(RequestBodyPublisher.class);
 
@@ -44,7 +44,7 @@ public class RequestBodyPublisher implements ReadListener, Publisher<ByteBuffer>
 
 	private final DemandCounter demand = new DemandCounter();
 
-	private Subscriber<? super ByteBuffer> subscriber;
+	private Subscriber<? super Bytes> subscriber;
 
 	private boolean stalled;
 
@@ -56,7 +56,7 @@ public class RequestBodyPublisher implements ReadListener, Publisher<ByteBuffer>
 	}
 
 	@Override
-	public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+	public void subscribe(Subscriber<? super Bytes> subscriber) {
 		if (subscriber == null) {
 			throw new NullPointerException();
 		}
@@ -102,7 +102,7 @@ public class RequestBodyPublisher implements ReadListener, Publisher<ByteBuffer>
 
 //				logger.debug("Next: " + new String(copy, UTF_8));
 
-				this.subscriber.onNext(ByteBuffer.wrap(copy));
+				this.subscriber.onNext(Bytes.from(copy));
 
 			}
 		}

--- a/src/main/java/org/springframework/http/server/servlet31/ResponseBodySubscriber.java
+++ b/src/main/java/org/springframework/http/server/servlet31/ResponseBodySubscriber.java
@@ -17,7 +17,6 @@
 package org.springframework.http.server.servlet31;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 
@@ -25,14 +24,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import reactor.io.buffer.Buffer;
 
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 /**
  * @author Arjen Poutsma
  */
-public class ResponseBodySubscriber implements WriteListener, Subscriber<ByteBuffer> {
+public class ResponseBodySubscriber implements WriteListener, Subscriber<Bytes> {
 
 	private static final Log logger = LogFactory.getLog(ResponseBodySubscriber.class);
 
@@ -40,7 +39,7 @@ public class ResponseBodySubscriber implements WriteListener, Subscriber<ByteBuf
 
 	private Subscription subscription;
 
-	private ByteBuffer buffer;
+	private Bytes buffer;
 
 	private volatile boolean subscriberComplete = false;
 
@@ -55,7 +54,7 @@ public class ResponseBodySubscriber implements WriteListener, Subscriber<ByteBuf
 	}
 
 	@Override
-	public void onNext(ByteBuffer bytes) {
+	public void onNext(Bytes bytes) {
 
 		Assert.isNull(buffer);
 
@@ -88,7 +87,7 @@ public class ResponseBodySubscriber implements WriteListener, Subscriber<ByteBuf
 
 		if (ready) {
 			if (this.buffer != null) {
-				output.write(new Buffer(this.buffer).asBytes());
+				output.write(this.buffer.asBytes());
 				this.buffer = null;
 
 				if (!subscriberComplete) {

--- a/src/main/java/org/springframework/http/server/servlet31/Servlet31ServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/servlet31/Servlet31ServerHttpRequest.java
@@ -18,7 +18,6 @@ package org.springframework.http.server.servlet31;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Enumeration;
 import java.util.Map;
@@ -30,6 +29,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.ReactiveServerHttpRequest;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 import org.springframework.util.StringUtils;
@@ -41,13 +41,13 @@ public class Servlet31ServerHttpRequest implements ReactiveServerHttpRequest {
 
 	private final HttpServletRequest servletRequest;
 
-	private final Publisher<ByteBuffer> requestBodyPublisher;
+	private final Publisher<Bytes> requestBodyPublisher;
 
 	private HttpHeaders headers;
 
 
 	public Servlet31ServerHttpRequest(HttpServletRequest servletRequest,
-			Publisher<ByteBuffer> requestBodyPublisher) {
+			Publisher<Bytes> requestBodyPublisher) {
 
 		Assert.notNull(servletRequest, "HttpServletRequest must not be null");
 		this.servletRequest = servletRequest;
@@ -115,7 +115,7 @@ public class Servlet31ServerHttpRequest implements ReactiveServerHttpRequest {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
+	public Publisher<Bytes> getBody() {
 		return this.requestBodyPublisher;
 	}
 

--- a/src/main/java/org/springframework/http/server/servlet31/Servlet31ServerHttpResponse.java
+++ b/src/main/java/org/springframework/http/server/servlet31/Servlet31ServerHttpResponse.java
@@ -16,7 +16,6 @@
 
 package org.springframework.http.server.servlet31;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +28,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.ReactiveServerHttpResponse;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 /**
@@ -73,7 +73,7 @@ public class Servlet31ServerHttpResponse implements ReactiveServerHttpResponse {
 	}
 
 	@Override
-	public Publisher<Void> setBody(final Publisher<ByteBuffer> contentPublisher) {
+	public Publisher<Void> setBody(final Publisher<Bytes> contentPublisher) {
 		applyHeaders();
 		return (s -> contentPublisher.subscribe(subscriber));
 	}

--- a/src/main/java/org/springframework/http/server/undertow/RequestBodyPublisher.java
+++ b/src/main/java/org/springframework/http/server/undertow/RequestBodyPublisher.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 import io.undertow.connector.PooledByteBuffer;
@@ -38,7 +39,7 @@ import reactor.core.support.BackpressureUtils;
 /**
  * @author Marek Hawrylczak
  */
-class RequestBodyPublisher implements Publisher<ByteBuffer> {
+class RequestBodyPublisher implements Publisher<Bytes> {
 
 	private static final AtomicLongFieldUpdater<RequestBodySubscription> DEMAND =
 			AtomicLongFieldUpdater.newUpdater(RequestBodySubscription.class, "demand");
@@ -46,7 +47,7 @@ class RequestBodyPublisher implements Publisher<ByteBuffer> {
 
 	private final HttpServerExchange exchange;
 
-	private Subscriber<? super ByteBuffer> subscriber;
+	private Subscriber<? super Bytes> subscriber;
 
 
 	public RequestBodyPublisher(HttpServerExchange exchange) {
@@ -56,7 +57,7 @@ class RequestBodyPublisher implements Publisher<ByteBuffer> {
 
 
 	@Override
-	public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+	public void subscribe(Subscriber<? super Bytes> subscriber) {
 		if (subscriber == null) {
 			throw SpecificationExceptions.spec_2_13_exception();
 		}
@@ -156,7 +157,7 @@ class RequestBodyPublisher implements Publisher<ByteBuffer> {
 					}
 					else if (count == -1) {
 						if (buffer.position() > 0) {
-							doOnNext(buffer);
+							doOnNext(Bytes.from(buffer));
 						}
 						doOnComplete();
 					}
@@ -165,7 +166,7 @@ class RequestBodyPublisher implements Publisher<ByteBuffer> {
 							if (this.demand == 0) {
 								this.channel.suspendReads();
 							}
-							doOnNext(buffer);
+							doOnNext(Bytes.from(buffer));
 							if (this.demand > 0) {
 								scheduleNextMessage();
 							}
@@ -179,7 +180,7 @@ class RequestBodyPublisher implements Publisher<ByteBuffer> {
 			}
 		}
 
-		private void doOnNext(ByteBuffer buffer) {
+		private void doOnNext(Bytes buffer) {
 			this.draining = false;
 			buffer.flip();
 			subscriber.onNext(buffer);
@@ -221,7 +222,7 @@ class RequestBodyPublisher implements Publisher<ByteBuffer> {
 					}
 					else if (count == -1) {
 						if (buffer.position() > 0) {
-							doOnNext(buffer);
+							doOnNext(Bytes.from(buffer));
 						}
 						doOnComplete();
 					}
@@ -230,7 +231,7 @@ class RequestBodyPublisher implements Publisher<ByteBuffer> {
 							if (this.demand == 0) {
 								channel.suspendReads();
 							}
-							doOnNext(buffer);
+							doOnNext(Bytes.from(buffer));
 							if (this.demand > 0) {
 								scheduleNextMessage();
 							}

--- a/src/main/java/org/springframework/http/server/undertow/ResponseBodySubscriber.java
+++ b/src/main/java/org/springframework/http/server/undertow/ResponseBodySubscriber.java
@@ -36,11 +36,13 @@ import static org.xnio.ChannelListeners.closingChannelExceptionHandler;
 import static org.xnio.ChannelListeners.flushingChannelListener;
 import static org.xnio.IoUtils.safeClose;
 
+import org.springframework.core.io.Bytes;
+
 /**
  * @author Marek Hawrylczak
  * @author Rossen Stoyanchev
  */
-class ResponseBodySubscriber extends BaseSubscriber<ByteBuffer>
+class ResponseBodySubscriber extends BaseSubscriber<Bytes>
 		implements ChannelListener<StreamSinkChannel> {
 
 	private static final Log logger = LogFactory.getLog(ResponseBodySubscriber.class);
@@ -73,7 +75,7 @@ class ResponseBodySubscriber extends BaseSubscriber<ByteBuffer>
 	}
 
 	@Override
-	public void onNext(ByteBuffer buffer) {
+	public void onNext(Bytes buffer) {
 		super.onNext(buffer);
 
 		if (this.responseChannel == null) {
@@ -84,12 +86,12 @@ class ResponseBodySubscriber extends BaseSubscriber<ByteBuffer>
 		try {
 			int c;
 			do {
-				c = this.responseChannel.write(buffer);
+				c = this.responseChannel.write(buffer.asByteBuffer());
 			} while (buffer.hasRemaining() && c > 0);
 
 			if (buffer.hasRemaining()) {
 				this.writing.incrementAndGet();
-				enqueue(buffer);
+				enqueue(buffer.asByteBuffer());
 				this.responseChannel.getWriteSetter().set(this);
 				this.responseChannel.resumeWrites();
 			}

--- a/src/main/java/org/springframework/http/server/undertow/UndertowServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/undertow/UndertowServerHttpRequest.java
@@ -18,7 +18,6 @@ package org.springframework.http.server.undertow;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
@@ -27,6 +26,7 @@ import org.reactivestreams.Publisher;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.server.ReactiveServerHttpRequest;
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Marek Hawrylczak
@@ -36,12 +36,12 @@ class UndertowServerHttpRequest implements ReactiveServerHttpRequest {
 
 	private final HttpServerExchange exchange;
 
-	private final Publisher<ByteBuffer> body;
+	private final Publisher<Bytes> body;
 
 	private HttpHeaders headers;
 
 
-	public UndertowServerHttpRequest(HttpServerExchange exchange, Publisher<ByteBuffer> body) {
+	public UndertowServerHttpRequest(HttpServerExchange exchange, Publisher<Bytes> body) {
 		this.exchange = exchange;
 		this.body = body;
 	}
@@ -78,7 +78,7 @@ class UndertowServerHttpRequest implements ReactiveServerHttpRequest {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
+	public Publisher<Bytes> getBody() {
 		return this.body;
 	}
 

--- a/src/main/java/org/springframework/http/server/undertow/UndertowServerHttpResponse.java
+++ b/src/main/java/org/springframework/http/server/undertow/UndertowServerHttpResponse.java
@@ -16,13 +16,13 @@
 
 package org.springframework.http.server.undertow;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ReactiveServerHttpResponse;
+import org.springframework.core.io.Bytes;
 import org.springframework.util.Assert;
 
 import io.undertow.server.HttpServerExchange;
@@ -59,7 +59,7 @@ class UndertowServerHttpResponse implements ReactiveServerHttpResponse {
 
 
 	@Override
-	public Publisher<Void> setBody(Publisher<ByteBuffer> bodyPublisher) {
+	public Publisher<Void> setBody(Publisher<Bytes> bodyPublisher) {
 		applyHeaders();
 		return (subscriber -> bodyPublisher.subscribe(bodySubscriber));
 	}

--- a/src/main/java/org/springframework/util/BytesInputStream.java
+++ b/src/main/java/org/springframework/util/BytesInputStream.java
@@ -18,19 +18,20 @@ package org.springframework.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
+
+import org.springframework.core.io.Bytes;
 
 /**
  * Simple {@link InputStream} implementation that exposes currently
- * available content of a {@link ByteBuffer}.
+ * available content of a {@link Bytes}.
  *
  * From Jackson <a href="https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/util/ByteBufferBackedInputStream.java">ByteBufferBackedInputStream</a>
  */
-public class ByteBufferInputStream extends InputStream {
+public class BytesInputStream extends InputStream {
 
-	protected final ByteBuffer b;
+	protected final Bytes b;
 
-	public ByteBufferInputStream(ByteBuffer buf) {
+	public BytesInputStream(Bytes buf) {
 		b = buf;
 	}
 

--- a/src/main/java/org/springframework/util/BytesPublisherInputStream.java
+++ b/src/main/java/org/springframework/util/BytesPublisherInputStream.java
@@ -18,12 +18,13 @@ package org.springframework.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.util.concurrent.BlockingQueue;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 import reactor.Publishers;
+
+import org.springframework.core.io.Bytes;
 
 /**
  * {@code InputStream} implementation based on a byte array {@link Publisher}.
@@ -32,11 +33,11 @@ import reactor.Publishers;
  * @author Sebastien Deleuze
  * @author Stephane Maldini
  */
-public class ByteBufferPublisherInputStream extends InputStream {
+public class BytesPublisherInputStream extends InputStream {
 
-	private final BlockingQueue<ByteBuffer> queue;
+	private final BlockingQueue<Bytes> queue;
 
-	private ByteBufferInputStream currentStream;
+	private BytesInputStream currentStream;
 
 	private boolean completed;
 
@@ -46,7 +47,7 @@ public class ByteBufferPublisherInputStream extends InputStream {
 	 *
 	 * @param publisher the publisher to use
 	 */
-	public ByteBufferPublisherInputStream(Publisher<ByteBuffer> publisher) {
+	public BytesPublisherInputStream(Publisher<Bytes> publisher) {
 		this(publisher, 1);
 	}
 
@@ -57,7 +58,7 @@ public class ByteBufferPublisherInputStream extends InputStream {
 	 * @param requestSize the {@linkplain Subscription#request(long) request size} to use
 	 * on the publisher bound to Integer MAX
 	 */
-	public ByteBufferPublisherInputStream(Publisher<ByteBuffer> publisher, int requestSize) {
+	public BytesPublisherInputStream(Publisher<Bytes> publisher, int requestSize) {
 		Assert.notNull(publisher, "'publisher' must not be null");
 
 		this.queue = Publishers.toReadQueue(publisher, requestSize);
@@ -130,12 +131,12 @@ public class ByteBufferPublisherInputStream extends InputStream {
 			} else {
 				// take() blocks until next or complete() then return null,
 				// but that's OK since this is a *blocking* InputStream
-				ByteBuffer signal = this.queue.take();
+				Bytes signal = this.queue.take();
 				if(signal == null){
 					this.completed = true;
 					return null;
 				}
-				this.currentStream = new ByteBufferInputStream(signal);
+				this.currentStream = new BytesInputStream(signal);
 				return this.currentStream;
 			}
 		}

--- a/src/main/java/org/springframework/web/reactive/method/annotation/RequestBodyArgumentResolver.java
+++ b/src/main/java/org/springframework/web/reactive/method/annotation/RequestBodyArgumentResolver.java
@@ -16,7 +16,6 @@
 
 package org.springframework.web.reactive.method.annotation;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.reactivestreams.Publisher;
@@ -28,6 +27,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.ReactiveServerHttpRequest;
 import org.springframework.core.codec.Decoder;
+import org.springframework.core.io.Bytes;
 import org.springframework.web.reactive.method.HandlerMethodArgumentResolver;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,7 +63,7 @@ public class RequestBodyArgumentResolver implements HandlerMethodArgumentResolve
 			mediaType = MediaType.APPLICATION_OCTET_STREAM;
 		}
 		ResolvableType type = ResolvableType.forMethodParameter(parameter);
-		Publisher<ByteBuffer> body = request.getBody();
+		Publisher<Bytes> body = request.getBody();
 		Publisher<?> elementStream = body;
 		ResolvableType elementType = type.hasGenerics() ? type.getGeneric(0) : type;
 

--- a/src/main/java/org/springframework/web/reactive/method/annotation/RequestMappingHandlerAdapter.java
+++ b/src/main/java/org/springframework/web/reactive/method/annotation/RequestMappingHandlerAdapter.java
@@ -28,7 +28,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.server.ReactiveServerHttpRequest;
 import org.springframework.http.server.ReactiveServerHttpResponse;
-import org.springframework.core.codec.support.ByteBufferDecoder;
+import org.springframework.core.codec.support.BytesDecoder;
 import org.springframework.core.codec.Decoder;
 import org.springframework.core.codec.support.JacksonJsonDecoder;
 import org.springframework.core.codec.support.JsonObjectDecoder;
@@ -72,7 +72,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Initializin
 	public void afterPropertiesSet() throws Exception {
 		if (this.argumentResolvers == null) {
 
-			List<Decoder<?>> decoders = Arrays.asList(new ByteBufferDecoder(),
+			List<Decoder<?>> decoders = Arrays.asList(new BytesDecoder(),
 					new StringDecoder(), new JacksonJsonDecoder(new JsonObjectDecoder()));
 
 			this.argumentResolvers = new ArrayList<>();

--- a/src/test/java/org/springframework/http/server/RandomHandler.java
+++ b/src/test/java/org/springframework/http/server/RandomHandler.java
@@ -16,7 +16,6 @@
 
 package org.springframework.http.server;
 
-import java.nio.ByteBuffer;
 import java.util.Random;
 
 import org.apache.commons.logging.Log;
@@ -24,9 +23,9 @@ import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Streams;
 
+import org.springframework.core.io.Bytes;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -43,7 +42,7 @@ public class RandomHandler implements ReactiveHttpHandler {
 	@Override
 	public Publisher<Void> handle(ReactiveServerHttpRequest request, ReactiveServerHttpResponse response) {
 
-		request.getBody().subscribe(new Subscriber<ByteBuffer>() {
+		request.getBody().subscribe(new Subscriber<Bytes>() {
 			private Subscription s;
 
 			private int requestSize = 0;
@@ -55,14 +54,13 @@ public class RandomHandler implements ReactiveHttpHandler {
 			}
 
 			@Override
-			public void onNext(ByteBuffer bytes) {
-				requestSize += new Buffer(bytes).limit();
+			public void onNext(Bytes bytes) {
+				requestSize += bytes.limit();
 			}
 
 			@Override
 			public void onError(Throwable t) {
 				logger.error(t);
-
 			}
 
 			@Override
@@ -73,7 +71,7 @@ public class RandomHandler implements ReactiveHttpHandler {
 		});
 
 		response.getHeaders().setContentLength(RESPONSE_SIZE);
-		return response.setBody(Streams.just(ByteBuffer.wrap(randomBytes())));
+		return response.setBody(Streams.just(Bytes.from(randomBytes())));
 	}
 
 	private byte[] randomBytes() {

--- a/src/test/java/org/springframework/http/server/XmlHandler.java
+++ b/src/test/java/org/springframework/http/server/XmlHandler.java
@@ -28,7 +28,8 @@ import reactor.rx.Streams;
 
 import org.springframework.http.MediaType;
 import org.springframework.util.BufferOutputStream;
-import org.springframework.util.ByteBufferPublisherInputStream;
+import org.springframework.util.BytesPublisherInputStream;
+import org.springframework.core.io.Bytes;
 
 import static org.junit.Assert.fail;
 
@@ -49,7 +50,7 @@ public class XmlHandler implements ReactiveHttpHandler {
 
 			Runnable r = () -> {
 				try {
-					ByteBufferPublisherInputStream bis = new ByteBufferPublisherInputStream(request.getBody());
+					BytesPublisherInputStream bis = new BytesPublisherInputStream(request.getBody());
 
 					XmlHandlerIntegrationTests.Person johnDoe =
 						(XmlHandlerIntegrationTests.Person) unmarshaller.unmarshal(bis);
@@ -73,7 +74,7 @@ public class XmlHandler implements ReactiveHttpHandler {
 			bos.close();
 			buffer.flip();
 
-			return response.setBody(Streams.just(buffer.byteBuffer()));
+			return response.setBody(Streams.just(Bytes.from(buffer.byteBuffer())));
 		}
 		catch (Exception ex) {
 			logger.error(ex, ex);

--- a/src/test/java/org/springframework/reactive/codec/decoder/ByteBufferDecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/ByteBufferDecoderTests.java
@@ -22,20 +22,20 @@ import java.util.List;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
 
 import org.springframework.core.ResolvableType;
-import org.springframework.core.codec.support.ByteBufferDecoder;
+import org.springframework.core.codec.support.BytesDecoder;
 import org.springframework.http.MediaType;
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Sebastien Deleuze
  */
 public class ByteBufferDecoderTests {
 
-	private final ByteBufferDecoder decoder = new ByteBufferDecoder();
+	private final BytesDecoder decoder = new BytesDecoder();
 
 	@Test
 	public void canDecode() {
@@ -46,11 +46,11 @@ public class ByteBufferDecoderTests {
 
 	@Test
 	public void decode() throws InterruptedException {
-		ByteBuffer fooBuffer = Buffer.wrap("foo").byteBuffer();
-		ByteBuffer barBuffer = Buffer.wrap("bar").byteBuffer();
-		Stream<ByteBuffer> source = Streams.just(fooBuffer, barBuffer);
-		List<ByteBuffer> results = Streams.wrap(decoder.decode(source,
-				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class), null)).toList().await();
+		Bytes fooBuffer = Bytes.from("foo".getBytes());
+		Bytes barBuffer = Bytes.from("bar".getBytes());
+		Stream<Bytes> source = Streams.just(fooBuffer, barBuffer);
+		List<Bytes> results = Streams.wrap(decoder.decode(source,
+				ResolvableType.forClassWithGenerics(Publisher.class, Bytes.class), null)).toList().await();
 		assertEquals(2, results.size());
 		assertEquals(fooBuffer, results.get(0));
 		assertEquals(barBuffer, results.get(1));

--- a/src/test/java/org/springframework/reactive/codec/decoder/JacksonJsonDecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/JacksonJsonDecoderTests.java
@@ -16,14 +16,12 @@
 
 package org.springframework.reactive.codec.decoder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
 
@@ -31,6 +29,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.support.JacksonJsonDecoder;
 import org.springframework.http.MediaType;
 import org.springframework.reactive.codec.Pojo;
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Sebastien Deleuze
@@ -47,7 +46,7 @@ public class JacksonJsonDecoderTests {
 
 	@Test
 	public void decode() throws InterruptedException {
-		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer());
+		Stream<Bytes> source = Streams.just(Bytes.from("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}".getBytes()));
 		List<Object> results = Streams.wrap(decoder.decode(source, ResolvableType.forClass(Pojo.class), null))
 				.toList().await();
 		assertEquals(1, results.size());

--- a/src/test/java/org/springframework/reactive/codec/decoder/Jaxb2DecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/Jaxb2DecoderTests.java
@@ -16,14 +16,12 @@
 
 package org.springframework.reactive.codec.decoder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
 
@@ -31,6 +29,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.support.Jaxb2Decoder;
 import org.springframework.http.MediaType;
 import org.springframework.reactive.codec.Pojo;
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Sebastien Deleuze
@@ -48,7 +47,7 @@ public class Jaxb2DecoderTests {
 
 	@Test
 	public void decode() throws InterruptedException {
-		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("<?xml version=\"1.0\" encoding=\"UTF-8\"?><pojo><bar>barbar</bar><foo>foofoo</foo></pojo>").byteBuffer());
+		Stream<Bytes> source = Streams.just(Bytes.from("<?xml version=\"1.0\" encoding=\"UTF-8\"?><pojo><bar>barbar</bar><foo>foofoo</foo></pojo>".getBytes()));
 		List<Object> results = Streams.wrap(decoder.decode(source, ResolvableType.forClass(Pojo.class), null))
 				.toList().await();
 		assertEquals(1, results.size());

--- a/src/test/java/org/springframework/reactive/codec/decoder/JsonObjectDecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/JsonObjectDecoderTests.java
@@ -16,17 +16,16 @@
 
 package org.springframework.reactive.codec.decoder;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
 
 import org.springframework.core.codec.support.JsonObjectDecoder;
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Sebastien Deleuze
@@ -36,7 +35,7 @@ public class JsonObjectDecoderTests {
 	@Test
 	public void decodeSingleChunkToJsonObject() throws InterruptedException {
 		JsonObjectDecoder decoder = new JsonObjectDecoder();
-		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer());
+		Stream<Bytes> source = Streams.just(Bytes.from("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}".getBytes()));
 		List<String> results = Streams.wrap(decoder.decode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
@@ -49,7 +48,7 @@ public class JsonObjectDecoderTests {
 	@Test
 	public void decodeMultipleChunksToJsonObject() throws InterruptedException {
 		JsonObjectDecoder decoder = new JsonObjectDecoder();
-		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("{\"foo\": \"foofoo\"").byteBuffer(), Buffer.wrap(", \"bar\": \"barbar\"}").byteBuffer());
+		Stream<Bytes> source = Streams.just(Bytes.from("{\"foo\": \"foofoo\"".getBytes()), Bytes.from(", \"bar\": \"barbar\"}".getBytes()));
 		List<String> results = Streams.wrap(decoder.decode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
@@ -62,7 +61,7 @@ public class JsonObjectDecoderTests {
 	@Test
 	public void decodeSingleChunkToArray() throws InterruptedException {
 		JsonObjectDecoder decoder = new JsonObjectDecoder();
-		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("[{\"foo\": \"foofoo\", \"bar\": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]").byteBuffer());
+		Stream<Bytes> source = Streams.just(Bytes.from("[{\"foo\": \"foofoo\", \"bar\": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]".getBytes()));
 		List<String> results = Streams.wrap(decoder.decode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
@@ -76,7 +75,7 @@ public class JsonObjectDecoderTests {
 	@Test
 	public void decodeMultipleChunksToArray() throws InterruptedException {
 		JsonObjectDecoder decoder = new JsonObjectDecoder();
-		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("[{\"foo\": \"foofoo\", \"bar\"").byteBuffer(), Buffer.wrap(": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]").byteBuffer());
+		Stream<Bytes> source = Streams.just(Bytes.from("[{\"foo\": \"foofoo\", \"bar\"".getBytes()), Bytes.from(": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]".getBytes()));
 		List<String> results = Streams.wrap(decoder.decode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);

--- a/src/test/java/org/springframework/reactive/codec/decoder/StringDecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/StringDecoderTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.reactive.codec.decoder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -24,13 +23,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.support.StringDecoder;
 import org.springframework.http.MediaType;
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Sebastien Deleuze
@@ -48,7 +47,7 @@ public class StringDecoderTests {
 
 	@Test
 	public void decode() throws InterruptedException {
-		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("foo").byteBuffer(), Buffer.wrap("bar").byteBuffer());
+		Stream<Bytes> source = Streams.just(Bytes.from("foo".getBytes()), Bytes.from("bar".getBytes()));
 		List<String> results = Streams.wrap(decoder.decode(source,
 				ResolvableType.forClassWithGenerics(Publisher.class, String.class), null)).toList().await();
 		assertEquals(2, results.size());

--- a/src/test/java/org/springframework/reactive/codec/encoder/ByteBufferEncoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/encoder/ByteBufferEncoderTests.java
@@ -16,41 +16,40 @@
 
 package org.springframework.reactive.codec.encoder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
 
 import org.springframework.core.ResolvableType;
-import org.springframework.core.codec.support.ByteBufferEncoder;
+import org.springframework.core.codec.support.BytesEncoder;
 import org.springframework.http.MediaType;
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Sebastien Deleuze
  */
 public class ByteBufferEncoderTests {
 
-	private final ByteBufferEncoder encoder = new ByteBufferEncoder();
+	private final BytesEncoder encoder = new BytesEncoder();
 
 	@Test
 	public void canDecode() {
-		assertTrue(encoder.canEncode(ResolvableType.forClass(ByteBuffer.class), MediaType.TEXT_PLAIN));
+		assertTrue(encoder.canEncode(ResolvableType.forClass(Bytes.class), MediaType.TEXT_PLAIN));
 		assertFalse(encoder.canEncode(ResolvableType.forClass(Integer.class), MediaType.TEXT_PLAIN));
-		assertTrue(encoder.canEncode(ResolvableType.forClass(ByteBuffer.class), MediaType.APPLICATION_JSON));
+		assertTrue(encoder.canEncode(ResolvableType.forClass(Bytes.class), MediaType.APPLICATION_JSON));
 	}
 
 	@Test
 	public void decode() throws InterruptedException {
-		ByteBuffer fooBuffer = Buffer.wrap("foo").byteBuffer();
-		ByteBuffer barBuffer = Buffer.wrap("bar").byteBuffer();
-		Stream<ByteBuffer> source = Streams.just(fooBuffer, barBuffer);
-		List<ByteBuffer> results = Streams.wrap(encoder.encode(source,
-				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class), null)).toList().await();
+		Bytes fooBuffer = Bytes.from("foo".getBytes());
+		Bytes barBuffer = Bytes.from("bar".getBytes());
+		Stream<Bytes> source = Streams.just(fooBuffer, barBuffer);
+		List<Bytes> results = Streams.wrap(encoder.encode(source,
+				ResolvableType.forClassWithGenerics(Publisher.class, Bytes.class), null)).toList().await();
 		assertEquals(2, results.size());
 		assertEquals(fooBuffer, results.get(0));
 		assertEquals(barBuffer, results.get(1));

--- a/src/test/java/org/springframework/reactive/codec/encoder/JsonObjectEncoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/encoder/JsonObjectEncoderTests.java
@@ -16,17 +16,16 @@
 
 package org.springframework.reactive.codec.encoder;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
 
 import org.springframework.core.codec.support.JsonObjectEncoder;
+import org.springframework.core.io.Bytes;
 
 /**
  * @author Sebastien Deleuze
@@ -36,7 +35,7 @@ public class JsonObjectEncoderTests {
 	@Test
 	public void encodeSingleElement() throws InterruptedException {
 		JsonObjectEncoder encoder = new JsonObjectEncoder();
-		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer());
+		Stream<Bytes> source = Streams.just(Bytes.from("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}".getBytes()));
 		List<String> results = Streams.wrap(encoder.encode(source, null, null)).map(chunk -> {
 			byte[] b = new byte[chunk.remaining()];
 			chunk.get(b);
@@ -49,9 +48,9 @@ public class JsonObjectEncoderTests {
 	@Test
 	public void encodeTwoElements() throws InterruptedException {
 		JsonObjectEncoder encoder = new JsonObjectEncoder();
-		Stream<ByteBuffer> source = Streams.just(
-				Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer(),
-				Buffer.wrap("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}").byteBuffer());
+		Stream<Bytes> source = Streams.just(
+				Bytes.from("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}".getBytes()),
+				Bytes.from("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}".getBytes()));
 		List<String> results = Streams.wrap(encoder.encode(source, null, null)).map(chunk -> {
 			byte[] b = new byte[chunk.remaining()];
 			chunk.get(b);
@@ -64,10 +63,10 @@ public class JsonObjectEncoderTests {
 	@Test
 	public void encodeThreeElements() throws InterruptedException {
 		JsonObjectEncoder encoder = new JsonObjectEncoder();
-		Stream<ByteBuffer> source = Streams.just(
-				Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer(),
-				Buffer.wrap("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}").byteBuffer(),
-				Buffer.wrap("{\"foo\": \"foofoofoofoo\", \"bar\": \"barbarbarbar\"}").byteBuffer()
+		Stream<Bytes> source = Streams.just(
+				Bytes.from("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}".getBytes()),
+				Bytes.from("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}".getBytes()),
+				Bytes.from("{\"foo\": \"foofoofoofoo\", \"bar\": \"barbarbarbar\"}".getBytes())
 		);
 		List<String> results = Streams.wrap(encoder.encode(source, null, null)).map(chunk -> {
 			byte[] b = new byte[chunk.remaining()];

--- a/src/test/java/org/springframework/web/reactive/handler/SimpleUrlHandlerMappingIntegrationTests.java
+++ b/src/test/java/org/springframework/web/reactive/handler/SimpleUrlHandlerMappingIntegrationTests.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Streams;
 
 import org.springframework.http.HttpStatus;
@@ -31,6 +30,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.ReactiveServerHttpRequest;
 import org.springframework.http.server.ReactiveServerHttpResponse;
+import org.springframework.core.io.Bytes;
 import org.springframework.web.reactive.DispatcherHandler;
 import org.springframework.http.server.AbstractHttpHandlerIntegrationTests;
 import org.springframework.http.server.ReactiveHttpHandler;
@@ -104,7 +104,7 @@ public class SimpleUrlHandlerMappingIntegrationTests extends AbstractHttpHandler
 
 		@Override
 		public Publisher<Void> handle(ReactiveServerHttpRequest request, ReactiveServerHttpResponse response) {
-			return response.setBody(Streams.just(Buffer.wrap("foo").byteBuffer()));
+			return response.setBody(Streams.just(Bytes.from("foo".getBytes())));
 		}
 	}
 
@@ -112,7 +112,7 @@ public class SimpleUrlHandlerMappingIntegrationTests extends AbstractHttpHandler
 
 		@Override
 		public Publisher<Void> handle(ReactiveServerHttpRequest request, ReactiveServerHttpResponse response) {
-			return response.setBody(Streams.just(Buffer.wrap("bar").byteBuffer()));
+			return response.setBody(Streams.just(Bytes.from("bar".getBytes())));
 		}
 	}
 

--- a/src/test/java/org/springframework/web/reactive/method/annotation/RequestMappingHandlerMappingTests.java
+++ b/src/test/java/org/springframework/web/reactive/method/annotation/RequestMappingHandlerMappingTests.java
@@ -18,7 +18,6 @@ package org.springframework.web.reactive.method.annotation;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +26,7 @@ import org.reactivestreams.Publisher;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.server.ReactiveServerHttpRequest;
+import org.springframework.core.io.Bytes;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -118,7 +118,7 @@ public class RequestMappingHandlerMappingTests {
 		}
 
 		@Override
-		public Publisher<ByteBuffer> getBody() {
+		public Publisher<Bytes> getBody() {
 			return null;
 		}
 

--- a/src/test/java/org/springframework/web/reactive/method/annotation/RequestMappingIntegrationTests.java
+++ b/src/test/java/org/springframework/web/reactive/method/annotation/RequestMappingIntegrationTests.java
@@ -18,7 +18,6 @@ package org.springframework.web.reactive.method.annotation;
 
 
 import java.net.URI;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,7 +25,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
-import reactor.io.buffer.Buffer;
 import reactor.rx.Promise;
 import reactor.rx.Promises;
 import reactor.rx.Stream;
@@ -47,10 +45,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
-import org.springframework.core.codec.support.ByteBufferEncoder;
+import org.springframework.core.codec.support.BytesEncoder;
 import org.springframework.core.codec.support.JacksonJsonEncoder;
 import org.springframework.core.codec.support.JsonObjectEncoder;
 import org.springframework.core.codec.support.StringEncoder;
+import org.springframework.core.io.Bytes;
 import org.springframework.web.reactive.DispatcherHandler;
 import org.springframework.web.reactive.handler.SimpleHandlerResultHandler;
 import org.springframework.http.server.AbstractHttpHandlerIntegrationTests;
@@ -290,7 +289,7 @@ public class RequestMappingIntegrationTests extends AbstractHttpHandlerIntegrati
 		@Bean
 		public ResponseBodyResultHandler responseBodyResultHandler() {
 			return new ResponseBodyResultHandler(Arrays.asList(
-					new ByteBufferEncoder(), new StringEncoder(), new JacksonJsonEncoder(new JsonObjectEncoder())),
+					new BytesEncoder(), new StringEncoder(), new JacksonJsonEncoder(new JsonObjectEncoder())),
 					conversionService());
 		}
 
@@ -338,7 +337,7 @@ public class RequestMappingIntegrationTests extends AbstractHttpHandlerIntegrati
 
 		@RequestMapping("/raw")
 		@ResponseBody
-		public Publisher<ByteBuffer> rawResponseBody() {
+		public Publisher<Bytes> rawResponseBody() {
 			JacksonJsonEncoder encoder = new JacksonJsonEncoder();
 			return encoder.encode(Streams.just(new Person("Robert")),
 					ResolvableType.forClass(Person.class), MediaType.APPLICATION_JSON);
@@ -346,8 +345,8 @@ public class RequestMappingIntegrationTests extends AbstractHttpHandlerIntegrati
 
 		@RequestMapping("/raw-observable")
 		@ResponseBody
-		public Observable<ByteBuffer> rawObservableResponseBody() {
-			return Observable.just(Buffer.wrap("Hello!").byteBuffer());
+		public Observable<Bytes> rawObservableResponseBody() {
+			return Observable.just(Bytes.from("Hello!".getBytes()));
 		}
 
 		@RequestMapping("/single")


### PR DESCRIPTION
The goal of this PR is to use exactly the methods we currently need in the codebase, without exposing `java.nio.ByteBuffer`, Netty `ByteBuf` or Reactor `Buffer` types. This will allow us to experiment about what `Bytes` API should be, and about various implementations.