### PR TITLE
Publisher types with basic operators for multiple, single and no value emitted

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ group = 'org.springframework.reactive'
 
 repositories {
 	mavenCentral()
-	mavenLocal()
 	maven { url 'https://oss.jfrog.org/libs-snapshot' }  // RxNetty 0.5.x snapshots
 	maven { url 'http://repo.spring.io/snapshot' }  // Reactor snapshot
+	mavenLocal()
 }
 
 configurations.all {
@@ -32,7 +32,7 @@ configurations.all {
 
 ext {
 	springVersion = '4.2.3.RELEASE'
-	reactorVersion = '2.1.0.BUILD-SNAPSHOT'
+	reactorVersion = '2.5.0.BUILD-SNAPSHOT'
 	tomcatVersion = '8.0.28'
 	jettyVersion = '9.3.5.v20151012'
 }

--- a/src/main/java/org/springframework/core/codec/Decoder.java
+++ b/src/main/java/org/springframework/core/codec/Decoder.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.util.MimeType;
@@ -49,7 +50,7 @@ public interface Decoder<T> {
 	 * @param hints Additional information about how to do decode, optional.
 	 * @return the output stream
 	 */
-	Publisher<T> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	Flux<T> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints);
 
 	/**

--- a/src/main/java/org/springframework/core/codec/Encoder.java
+++ b/src/main/java/org/springframework/core/codec/Encoder.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.util.MimeType;
@@ -49,7 +50,7 @@ public interface Encoder<T> {
 	 * @param hints Additional information about how to do decode, optional.
 	 * @return the output stream
 	 */
-	Publisher<ByteBuffer> encode(Publisher<? extends T> inputStream, ResolvableType type,
+	Flux<ByteBuffer> encode(Publisher<? extends T> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints);
 
 	/**

--- a/src/main/java/org/springframework/core/codec/support/ByteBufferDecoder.java
+++ b/src/main/java/org/springframework/core/codec/support/ByteBufferDecoder.java
@@ -19,6 +19,7 @@ package org.springframework.core.codec.support;
 import java.nio.ByteBuffer;
 
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.util.MimeType;
@@ -42,10 +43,10 @@ public class ByteBufferDecoder extends AbstractDecoder<ByteBuffer> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Flux<ByteBuffer> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
-		return inputStream;
+		return Flux.from(inputStream);
 	}
 
 }

--- a/src/main/java/org/springframework/core/codec/support/ByteBufferEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/ByteBufferEncoder.java
@@ -19,6 +19,7 @@ package org.springframework.core.codec.support;
 import java.nio.ByteBuffer;
 
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.util.MimeType;
@@ -42,11 +43,11 @@ public class ByteBufferEncoder extends AbstractEncoder<ByteBuffer> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends ByteBuffer> inputStream, ResolvableType type,
+	public Flux<ByteBuffer> encode(Publisher<? extends ByteBuffer> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		//noinspection unchecked
-		return (Publisher<ByteBuffer>) inputStream;
+		return Flux.from((Publisher<ByteBuffer>)inputStream);
 	}
 
 }

--- a/src/main/java/org/springframework/core/codec/support/JacksonJsonDecoder.java
+++ b/src/main/java/org/springframework/core/codec/support/JacksonJsonDecoder.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.CodecException;
@@ -62,16 +62,17 @@ public class JacksonJsonDecoder extends AbstractDecoder<Object> {
 
 
 	@Override
-	public Publisher<Object> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Flux<Object> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		ObjectReader reader = this.mapper.readerFor(type.getRawClass());
 
+		Flux<ByteBuffer> stream = Flux.from(inputStream);
 		if (this.preProcessor != null) {
-			inputStream = this.preProcessor.decode(inputStream, type, mimeType, hints);
+			stream = this.preProcessor.decode(inputStream, type, mimeType, hints);
 		}
 
-		return Publishers.map(inputStream, content -> {
+		return stream.map(content -> {
 			try {
 				return reader.readValue(new ByteBufferInputStream(content));
 			}

--- a/src/main/java/org/springframework/core/codec/support/JacksonJsonEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/JacksonJsonEncoder.java
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
 import reactor.io.buffer.Buffer;
 
 import org.springframework.core.ResolvableType;
@@ -61,10 +61,10 @@ public class JacksonJsonEncoder extends AbstractEncoder<Object> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends Object> inputStream,
+	public Flux<ByteBuffer> encode(Publisher<? extends Object> inputStream,
 			ResolvableType type, MimeType mimeType, Object... hints) {
 
-		Publisher<ByteBuffer> stream = Publishers.map(inputStream, value -> {
+		Flux<ByteBuffer> stream = Flux.from(inputStream).map(value -> {
 			Buffer buffer = new Buffer();
 			BufferOutputStream outputStream = new BufferOutputStream(buffer);
 			try {

--- a/src/main/java/org/springframework/core/codec/support/Jaxb2Decoder.java
+++ b/src/main/java/org/springframework/core/codec/support/Jaxb2Decoder.java
@@ -34,7 +34,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
-import reactor.Publishers;
+import reactor.Flux;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.CodecException;
@@ -60,7 +60,7 @@ public class Jaxb2Decoder extends AbstractDecoder<Object> {
 
 
 	@Override
-	public Publisher<Object> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Flux<Object> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		Class<?> outputClass = type.getRawClass();
@@ -68,19 +68,19 @@ public class Jaxb2Decoder extends AbstractDecoder<Object> {
 			Source source = processSource(new StreamSource(new ByteBufferPublisherInputStream(inputStream)));
 			Unmarshaller unmarshaller = createUnmarshaller(outputClass);
 			if (outputClass.isAnnotationPresent(XmlRootElement.class)) {
-				return Publishers.just(unmarshaller.unmarshal(source));
+				return Flux.just(unmarshaller.unmarshal(source));
 			}
 			else {
 				JAXBElement<?> jaxbElement = unmarshaller.unmarshal(source, outputClass);
-				return Publishers.just(jaxbElement.getValue());
+				return Flux.just(jaxbElement.getValue());
 			}
 		}
 		catch (UnmarshalException ex) {
-			return Publishers.error(
+			return Flux.error(
 			  new CodecException("Could not unmarshal to [" + outputClass + "]: " + ex.getMessage(), ex));
 		}
 		catch (JAXBException ex) {
-			return Publishers.error(new CodecException("Could not instantiate JAXBContext: " +
+			return Flux.error(new CodecException("Could not instantiate JAXBContext: " +
 					ex.getMessage(), ex));
 		}
 	}

--- a/src/main/java/org/springframework/core/codec/support/Jaxb2Encoder.java
+++ b/src/main/java/org/springframework/core/codec/support/Jaxb2Encoder.java
@@ -26,7 +26,7 @@ import javax.xml.bind.MarshalException;
 import javax.xml.bind.Marshaller;
 
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
 import reactor.io.buffer.Buffer;
 
 import org.springframework.core.ResolvableType;
@@ -54,10 +54,10 @@ public class Jaxb2Encoder extends AbstractEncoder<Object> {
 
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends Object> messageStream, ResolvableType type,
+	public Flux<ByteBuffer> encode(Publisher<? extends Object> messageStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
-		return Publishers.map(messageStream, value -> {
+		return Flux.from(messageStream).map(value -> {
 			try {
 				Buffer buffer = new Buffer();
 				BufferOutputStream outputStream = new BufferOutputStream(buffer);

--- a/src/main/java/org/springframework/core/codec/support/JsonObjectEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/JsonObjectEncoder.java
@@ -23,14 +23,13 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
+import reactor.Flux;
 import reactor.core.subscriber.SubscriberBarrier;
 import reactor.core.support.BackpressureUtils;
 import reactor.io.buffer.Buffer;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.util.MimeType;
-
-import static reactor.Publishers.lift;
 
 /**
  * Encode a byte stream of individual JSON element to a byte stream representing
@@ -49,11 +48,11 @@ public class JsonObjectEncoder extends AbstractEncoder<ByteBuffer> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends ByteBuffer> messageStream,
+	public Flux<ByteBuffer> encode(Publisher<? extends ByteBuffer> messageStream,
 			ResolvableType type, MimeType mimeType, Object... hints) {
 
 		//noinspection Convert2MethodRef
-		return lift(messageStream, bbs -> new JsonEncoderBarrier(bbs));
+		return Flux.from(messageStream).lift(bbs -> new JsonEncoderBarrier(bbs));
 	}
 
 

--- a/src/main/java/org/springframework/core/codec/support/StringDecoder.java
+++ b/src/main/java/org/springframework/core/codec/support/StringDecoder.java
@@ -21,7 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
 import reactor.io.buffer.Buffer;
 
 import org.springframework.core.ResolvableType;
@@ -48,7 +48,7 @@ public class StringDecoder extends AbstractDecoder<String> {
 	}
 
 	@Override
-	public Publisher<String> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
+	public Flux<String> decode(Publisher<ByteBuffer> inputStream, ResolvableType type,
 			MimeType mimeType, Object... hints) {
 
 		Charset charset;
@@ -58,7 +58,7 @@ public class StringDecoder extends AbstractDecoder<String> {
 		else {
 			 charset = DEFAULT_CHARSET;
 		}
-		return Publishers.map(inputStream, content -> new String(new Buffer(content).asBytes(), charset));
+		return Flux.from(inputStream).map(content -> new String(new Buffer(content).asBytes(), charset));
 	}
 
 }

--- a/src/main/java/org/springframework/core/codec/support/StringEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/StringEncoder.java
@@ -21,7 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.util.MimeType;
@@ -49,7 +49,7 @@ public class StringEncoder extends AbstractEncoder<String> {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> encode(Publisher<? extends String> elementStream,
+	public Flux<ByteBuffer> encode(Publisher<? extends String> elementStream,
 			ResolvableType type, MimeType mimeType, Object... hints) {
 
 		Charset charset;
@@ -59,7 +59,7 @@ public class StringEncoder extends AbstractEncoder<String> {
 		else {
 			 charset = DEFAULT_CHARSET;
 		}
-		return Publishers.map(elementStream, s -> ByteBuffer.wrap(s.getBytes(charset)));
+		return Flux.from(elementStream).map(s -> ByteBuffer.wrap(s.getBytes(charset)));
 	}
 
 }

--- a/src/main/java/org/springframework/core/convert/support/ReactiveStreamsToReactorStreamConverter.java
+++ b/src/main/java/org/springframework/core/convert/support/ReactiveStreamsToReactorStreamConverter.java
@@ -31,7 +31,7 @@ import org.springframework.core.convert.converter.GenericConverter;
  * @author Stephane Maldini
  * @author Sebastien Deleuze
  */
-public final class ReactiveStreamsToReactorConverter implements GenericConverter {
+public final class ReactiveStreamsToReactorStreamConverter implements GenericConverter {
 
 	@Override
 	public Set<GenericConverter.ConvertiblePair> getConvertibleTypes() {
@@ -52,13 +52,13 @@ public final class ReactiveStreamsToReactorConverter implements GenericConverter
 			return source;
 		}
 		else if (Stream.class.isAssignableFrom(targetType.getResolvableType().getRawClass())) {
-			return Streams.wrap((Publisher)source);
+			return Streams.from((Publisher)source);
 		}
 		else if (Promise.class.isAssignableFrom(source.getClass())) {
 			return source;
 		}
 		else if (Promise.class.isAssignableFrom(targetType.getResolvableType().getRawClass())) {
-			return Streams.wrap((Publisher)source).next();
+			return Streams.from((Publisher)source).promise();
 		}
 		return null;
 	}

--- a/src/main/java/org/springframework/http/ReactiveHttpInputMessage.java
+++ b/src/main/java/org/springframework/http/ReactiveHttpInputMessage.java
@@ -19,6 +19,7 @@ package org.springframework.http;
 import java.nio.ByteBuffer;
 
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 
 /**
  * An "reactive" HTTP input message that exposes the input as {@link Publisher}.
@@ -34,6 +35,6 @@ public interface ReactiveHttpInputMessage extends HttpMessage {
 	 * Return the body of the message as a {@link Publisher}.
 	 * @return the body content publisher
 	 */
-	Publisher<ByteBuffer> getBody();
+	Flux<ByteBuffer> getBody();
 
 }

--- a/src/main/java/org/springframework/http/ReactiveHttpOutputMessage.java
+++ b/src/main/java/org/springframework/http/ReactiveHttpOutputMessage.java
@@ -19,6 +19,7 @@ package org.springframework.http;
 import java.nio.ByteBuffer;
 
 import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 /**
  * A "reactive" HTTP output message that accepts output as a {@link Publisher}.
@@ -37,6 +38,6 @@ public interface ReactiveHttpOutputMessage extends HttpMessage {
 	 * @param body the body content publisher
 	 * @return a publisher that indicates completion or error.
 	 */
-	Publisher<Void> setBody(Publisher<ByteBuffer> body);
+	Mono<Void> setBody(Publisher<ByteBuffer> body);
 
 }

--- a/src/main/java/org/springframework/http/server/reactive/FilterChainHttpHandler.java
+++ b/src/main/java/org/springframework/http/server/reactive/FilterChainHttpHandler.java
@@ -19,8 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.reactivestreams.Publisher;
-
+import reactor.Mono;
 
 /**
  * {@link HttpHandler} that delegates to a chain of {@link HttpFilter}s followed
@@ -40,7 +39,7 @@ public class FilterChainHttpHandler extends HttpHandlerDecorator {
 
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+	public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 		return new DefaultHttpFilterChain().filter(request, response);
 	}
 
@@ -50,7 +49,7 @@ public class FilterChainHttpHandler extends HttpHandlerDecorator {
 		private int index;
 
 		@Override
-		public Publisher<Void> filter(ServerHttpRequest request, ServerHttpResponse response) {
+		public Mono<Void> filter(ServerHttpRequest request, ServerHttpResponse response) {
 			if (this.index < filters.size()) {
 				HttpFilter filter = filters.get(this.index++);
 				return filter.filter(request, response, this);

--- a/src/main/java/org/springframework/http/server/reactive/HttpExceptionHandler.java
+++ b/src/main/java/org/springframework/http/server/reactive/HttpExceptionHandler.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.http.server.reactive;
 
-import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 /**
  * A contract for resolving exceptions from HTTP request handling.
@@ -38,6 +38,6 @@ public interface HttpExceptionHandler {
 	 * @param ex the exception to handle
 	 * @return Publisher to indicate when exception handling is complete.
 	 */
-	Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response, Throwable ex);
+	Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response, Throwable ex);
 
 }

--- a/src/main/java/org/springframework/http/server/reactive/HttpFilter.java
+++ b/src/main/java/org/springframework/http/server/reactive/HttpFilter.java
@@ -17,6 +17,7 @@
 package org.springframework.http.server.reactive;
 
 import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 /**
  * Contract for interception-style, chained processing of HTTP requests.
@@ -40,7 +41,7 @@ public interface HttpFilter {
 	 * @param chain provides a way to delegate to the next HttpFilter.
 	 * @return Publisher to indicate when request processing is complete.
 	 */
-	Publisher<Void> filter(ServerHttpRequest request, ServerHttpResponse response,
+	Mono<Void> filter(ServerHttpRequest request, ServerHttpResponse response,
 			HttpFilterChain chain);
 
 }

--- a/src/main/java/org/springframework/http/server/reactive/HttpFilterChain.java
+++ b/src/main/java/org/springframework/http/server/reactive/HttpFilterChain.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.http.server.reactive;
 
-import org.reactivestreams.Publisher;
-
+import reactor.Mono;
 
 /**
  * Represents a chain of {@link HttpFilter}s allowing each {@link HttpFilter} to
@@ -32,6 +31,6 @@ public interface HttpFilterChain {
 	 * @param response current HTTP response.
 	 * @return Publisher to indicate when request handling is complete.
 	 */
-	Publisher<Void> filter(ServerHttpRequest request, ServerHttpResponse response);
+	Mono<Void> filter(ServerHttpRequest request, ServerHttpResponse response);
 
 }

--- a/src/main/java/org/springframework/http/server/reactive/HttpHandler.java
+++ b/src/main/java/org/springframework/http/server/reactive/HttpHandler.java
@@ -16,7 +16,7 @@
 
 package org.springframework.http.server.reactive;
 
-import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 /**
  * Contract for handling HTTP requests in a non-blocking way.
@@ -35,6 +35,6 @@ public interface HttpHandler {
 	 * @param response current HTTP response.
 	 * @return Publisher to indicate when request handling is complete.
 	 */
-	Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response);
+	Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response);
 
 }

--- a/src/main/java/org/springframework/http/server/reactive/HttpHandlerDecorator.java
+++ b/src/main/java/org/springframework/http/server/reactive/HttpHandlerDecorator.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.http.server.reactive;
 
-import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 import org.springframework.util.Assert;
 
@@ -40,7 +40,7 @@ public class HttpHandlerDecorator implements HttpHandler {
 
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+	public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 		return this.delegate.handle(request, response);
 	}
 

--- a/src/main/java/org/springframework/http/server/reactive/InternalServerErrorExceptionHandler.java
+++ b/src/main/java/org/springframework/http/server/reactive/InternalServerErrorExceptionHandler.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.http.server.reactive;
 
-import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Mono;
 
 import org.springframework.http.HttpStatus;
 
@@ -29,9 +28,9 @@ public class InternalServerErrorExceptionHandler implements HttpExceptionHandler
 
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response, Throwable ex) {
+	public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response, Throwable ex) {
 		response.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
-		return Publishers.empty();
+		return Mono.empty();
 	}
 
 }

--- a/src/main/java/org/springframework/http/server/reactive/ReactorHttpHandlerAdapter.java
+++ b/src/main/java/org/springframework/http/server/reactive/ReactorHttpHandlerAdapter.java
@@ -15,14 +15,11 @@
  */
 package org.springframework.http.server.reactive;
 
-import org.reactivestreams.Publisher;
+import reactor.Mono;
 import reactor.io.buffer.Buffer;
 import reactor.io.net.ReactiveChannelHandler;
 import reactor.io.net.http.HttpChannel;
 
-import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.http.server.reactive.ReactorServerHttpRequest;
-import org.springframework.http.server.reactive.ReactorServerHttpResponse;
 import org.springframework.util.Assert;
 
 /**
@@ -40,7 +37,7 @@ public class ReactorHttpHandlerAdapter
 	}
 
 	@Override
-	public Publisher<Void> apply(HttpChannel<Buffer, Buffer> channel) {
+	public Mono<Void> apply(HttpChannel<Buffer, Buffer> channel) {
 		ReactorServerHttpRequest adaptedRequest = new ReactorServerHttpRequest(channel);
 		ReactorServerHttpResponse adaptedResponse = new ReactorServerHttpResponse(channel);
 		return this.httpHandler.handle(adaptedRequest, adaptedResponse);

--- a/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
@@ -19,8 +19,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 
-import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
 import reactor.io.buffer.Buffer;
 import reactor.io.net.http.HttpChannel;
 
@@ -82,8 +81,8 @@ public class ReactorServerHttpRequest implements ServerHttpRequest {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
-		return Publishers.map(this.channel.input(), Buffer::byteBuffer);
+	public Flux<ByteBuffer> getBody() {
+		return Flux.from(this.channel.input()).map(Buffer::byteBuffer);
 	}
 
 }

--- a/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpResponse.java
+++ b/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpResponse.java
@@ -19,7 +19,8 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
+import reactor.Mono;
 import reactor.io.buffer.Buffer;
 import reactor.io.net.http.HttpChannel;
 import reactor.io.net.http.model.Status;
@@ -64,12 +65,12 @@ public class ReactorServerHttpResponse implements ServerHttpResponse {
 	}
 
 	@Override
-	public Publisher<Void> setBody(Publisher<ByteBuffer> publisher) {
-		return Publishers.lift(publisher, new WriteWithOperator<>(this::setBodyInternal));
+	public Mono<Void> setBody(Publisher<ByteBuffer> publisher) {
+		return Flux.from(publisher).lift(new WriteWithOperator<>(this::setBodyInternal)).after();
 	}
 
-	protected Publisher<Void> setBodyInternal(Publisher<ByteBuffer> publisher) {
-		return getReactorChannel().writeWith(Publishers.map(publisher, Buffer::new));
+	protected Mono<Void> setBodyInternal(Publisher<ByteBuffer> publisher) {
+		return Mono.from(getReactorChannel().writeWith(Flux.from(publisher).map(Buffer::new)));
 	}
 
 

--- a/src/main/java/org/springframework/http/server/reactive/RxNettyServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/reactive/RxNettyServerHttpRequest.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import io.netty.buffer.ByteBuf;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 import reactor.core.publisher.convert.RxJava1Converter;
 import rx.Observable;
 
@@ -85,7 +86,7 @@ public class RxNettyServerHttpRequest implements ServerHttpRequest {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
+	public Flux<ByteBuffer> getBody() {
 		Observable<ByteBuffer> content = this.getRxNettyRequest().getContent().map(ByteBuf::nioBuffer);
 		content = content.concatWith(Observable.empty()); // See GH issue #58
 		return RxJava1Converter.from(content);

--- a/src/main/java/org/springframework/http/server/reactive/ServletHttpHandlerAdapter.java
+++ b/src/main/java/org/springframework/http/server/reactive/ServletHttpHandlerAdapter.java
@@ -36,6 +36,7 @@ import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.Mono;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.util.Assert;
@@ -73,7 +74,7 @@ public class ServletHttpHandlerAdapter extends HttpServlet {
 
 		ResponseBodySubscriber responseBodySubscriber = new ResponseBodySubscriber(synchronizer);
 		ServletServerHttpResponse response = new ServletServerHttpResponse(servletResponse,
-				publisher -> subscriber -> publisher.subscribe(responseBodySubscriber));
+				publisher -> Mono.from(subscriber -> publisher.subscribe(responseBodySubscriber)));
 		servletResponse.getOutputStream().setWriteListener(responseBodySubscriber);
 
 		HandlerResultSubscriber resultSubscriber = new HandlerResultSubscriber(synchronizer, response);

--- a/src/main/java/org/springframework/http/server/reactive/ServletServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/reactive/ServletServerHttpRequest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -46,14 +47,14 @@ public class ServletServerHttpRequest implements ServerHttpRequest {
 
 	private HttpHeaders headers;
 
-	private final Publisher<ByteBuffer> requestBodyPublisher;
+	private final Flux<ByteBuffer> requestBodyPublisher;
 
 
 	public ServletServerHttpRequest(HttpServletRequest request, Publisher<ByteBuffer> body) {
 		Assert.notNull(request, "'request' must not be null.");
 		Assert.notNull(body, "'body' must not be null.");
 		this.request = request;
-		this.requestBodyPublisher = body;
+		this.requestBodyPublisher = Flux.from(body);
 	}
 
 
@@ -126,7 +127,7 @@ public class ServletServerHttpRequest implements ServerHttpRequest {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
+	public Flux<ByteBuffer> getBody() {
 		return this.requestBodyPublisher;
 	}
 

--- a/src/main/java/org/springframework/http/server/reactive/UndertowHttpHandlerAdapter.java
+++ b/src/main/java/org/springframework/http/server/reactive/UndertowHttpHandlerAdapter.java
@@ -35,7 +35,8 @@ import org.reactivestreams.Subscription;
 import org.xnio.ChannelListener;
 import org.xnio.channels.StreamSinkChannel;
 import org.xnio.channels.StreamSourceChannel;
-import reactor.core.error.SpecificationExceptions;
+import reactor.Mono;
+import reactor.core.error.Exceptions;
 import reactor.core.subscriber.BaseSubscriber;
 import reactor.core.support.BackpressureUtils;
 
@@ -72,7 +73,7 @@ public class UndertowHttpHandlerAdapter implements io.undertow.server.HttpHandle
 
 		ResponseBodySubscriber responseBodySubscriber = new ResponseBodySubscriber(exchange);
 		ServerHttpResponse response = new UndertowServerHttpResponse(exchange,
-				publisher -> subscriber -> publisher.subscribe(responseBodySubscriber));
+				publisher -> Mono.from(subscriber -> publisher.subscribe(responseBodySubscriber)));
 
 		exchange.dispatch();
 
@@ -126,7 +127,7 @@ public class UndertowHttpHandlerAdapter implements io.undertow.server.HttpHandle
 		@Override
 		public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
 			if (subscriber == null) {
-				throw SpecificationExceptions.spec_2_13_exception();
+				throw Exceptions.spec_2_13_exception();
 			}
 			if (this.subscriber != null) {
 				subscriber.onError(new IllegalStateException("Only one subscriber allowed"));

--- a/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpRequest.java
+++ b/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpRequest.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -42,14 +43,14 @@ public class UndertowServerHttpRequest implements ServerHttpRequest {
 
 	private HttpHeaders headers;
 
-	private final Publisher<ByteBuffer> body;
+	private final Flux<ByteBuffer> body;
 
 
 	public UndertowServerHttpRequest(HttpServerExchange exchange, Publisher<ByteBuffer> body) {
 		Assert.notNull(exchange, "'exchange' is required.");
 		Assert.notNull(exchange, "'body' is required.");
 		this.exchange = exchange;
-		this.body = body;
+		this.body = Flux.from(body);
 	}
 
 
@@ -91,7 +92,7 @@ public class UndertowServerHttpRequest implements ServerHttpRequest {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
+	public Flux<ByteBuffer> getBody() {
 		return this.body;
 	}
 

--- a/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpResponse.java
+++ b/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpResponse.java
@@ -23,7 +23,8 @@ import java.util.function.Function;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
+import reactor.Mono;
 
 import org.springframework.http.ExtendedHttpHeaders;
 import org.springframework.http.HttpHeaders;
@@ -40,13 +41,13 @@ public class UndertowServerHttpResponse implements ServerHttpResponse {
 
 	private final HttpServerExchange exchange;
 
-	private final Function<Publisher<ByteBuffer>, Publisher<Void>> responseBodyWriter;
+	private final Function<Publisher<ByteBuffer>, Mono<Void>> responseBodyWriter;
 
 	private final HttpHeaders headers;
 
 
 	public UndertowServerHttpResponse(HttpServerExchange exchange,
-			Function<Publisher<ByteBuffer>, Publisher<Void>> responseBodyWriter) {
+			Function<Publisher<ByteBuffer>, Mono<Void>> responseBodyWriter) {
 
 		Assert.notNull(exchange, "'exchange' is required.");
 		Assert.notNull(responseBodyWriter, "'responseBodyWriter' must not be null");
@@ -72,11 +73,11 @@ public class UndertowServerHttpResponse implements ServerHttpResponse {
 	}
 
 	@Override
-	public Publisher<Void> setBody(Publisher<ByteBuffer> publisher) {
-		return Publishers.lift(publisher, new WriteWithOperator<>(this::setBodyInternal));
+	public Mono<Void> setBody(Publisher<ByteBuffer> publisher) {
+		return Flux.from(publisher).lift(new WriteWithOperator<>(this::setBodyInternal)).after();
 	}
 
-	protected Publisher<Void> setBodyInternal(Publisher<ByteBuffer> publisher) {
+	protected Mono<Void> setBodyInternal(Publisher<ByteBuffer> publisher) {
 		return this.responseBodyWriter.apply(publisher);
 	}
 

--- a/src/main/java/org/springframework/util/ByteBufferPublisherInputStream.java
+++ b/src/main/java/org/springframework/util/ByteBufferPublisherInputStream.java
@@ -23,7 +23,7 @@ import java.util.concurrent.BlockingQueue;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
-import reactor.Publishers;
+import reactor.rx.Streams;
 
 /**
  * {@code InputStream} implementation based on a byte array {@link Publisher}.
@@ -60,7 +60,7 @@ public class ByteBufferPublisherInputStream extends InputStream {
 	public ByteBufferPublisherInputStream(Publisher<ByteBuffer> publisher, int requestSize) {
 		Assert.notNull(publisher, "'publisher' must not be null");
 
-		this.queue = Publishers.toReadQueue(publisher, requestSize);
+		this.queue = Streams.from(publisher).toBlockingQueue(requestSize);
 	}
 
 

--- a/src/main/java/org/springframework/web/reactive/HandlerAdapter.java
+++ b/src/main/java/org/springframework/web/reactive/HandlerAdapter.java
@@ -17,6 +17,7 @@
 package org.springframework.web.reactive;
 
 import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -54,7 +55,7 @@ public interface HandlerAdapter {
 	 * returned {@code true}.
 	 * @return A {@link Publisher} object that produces a single {@link HandlerResult} element
 	 */
-	Publisher<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response,
+	Mono<HandlerResult> handle(ServerHttpRequest request, ServerHttpResponse response,
 			Object handler);
 
 }

--- a/src/main/java/org/springframework/web/reactive/HandlerMapping.java
+++ b/src/main/java/org/springframework/web/reactive/HandlerMapping.java
@@ -16,7 +16,7 @@
 
 package org.springframework.web.reactive;
 
-import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 import org.springframework.http.server.reactive.ServerHttpRequest;
 
@@ -32,8 +32,8 @@ public interface HandlerMapping {
 	/**
 	 * Return a handler for this request.
 	 * @param request current HTTP request
-	 * @return A {@link Publisher} object that produces a single handler element
+	 * @return A {@link Mono} object that produces a single handler element
 	 */
-	Publisher<Object> getHandler(ServerHttpRequest request);
+	Mono<Object> getHandler(ServerHttpRequest request);
 
 }

--- a/src/main/java/org/springframework/web/reactive/HandlerResult.java
+++ b/src/main/java/org/springframework/web/reactive/HandlerResult.java
@@ -17,10 +17,8 @@
 package org.springframework.web.reactive;
 
 import java.util.function.Function;
-import java.util.logging.Handler;
 
-import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Mono;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.util.Assert;
@@ -40,7 +38,7 @@ public class HandlerResult {
 
 	private final Throwable error;
 
-	private Function<Throwable, Publisher<HandlerResult>> exceptionMapper;
+	private Function<Throwable, Mono<HandlerResult>> exceptionMapper;
 
 
 	public HandlerResult(Object handler, Object result, ResolvableType resultType) {
@@ -95,12 +93,12 @@ public class HandlerResult {
 	 * that results in an error.
 	 * @param function the exception resolving function
 	 */
-	public HandlerResult setExceptionMapper(Function<Throwable, Publisher<HandlerResult>> function) {
+	public HandlerResult setExceptionMapper(Function<Throwable, Mono<HandlerResult>> function) {
 		this.exceptionMapper = function;
 		return this;
 	}
 
-	public Function<Throwable, Publisher<HandlerResult>> getExceptionMapper() {
+	public Function<Throwable, Mono<HandlerResult>> getExceptionMapper() {
 		return this.exceptionMapper;
 	}
 

--- a/src/main/java/org/springframework/web/reactive/HandlerResultHandler.java
+++ b/src/main/java/org/springframework/web/reactive/HandlerResultHandler.java
@@ -16,7 +16,7 @@
 
 package org.springframework.web.reactive;
 
-import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -42,13 +42,13 @@ public interface HandlerResultHandler {
 	 * Process the given result in an asynchronous non blocking way, by eventually modifying
 	 * response headers, or writing some data stream into the response.
 	 * Implementations should not throw exceptions but signal them via the returned
-	 * {@code Publisher<Void>}.
+	 * {@code Mono<Void>}.
 	 *
-	 * @return A {@code Publisher<Void>} used to signal the demand, and receive a notification
+	 * @return A {@code Mono<Void>} used to signal the demand, and receive a notification
 	 * when the handling is complete (success or error) including the flush of the data on the
 	 * network.
 	 */
-	Publisher<Void> handleResult(ServerHttpRequest request, ServerHttpResponse response,
+	Mono<Void> handleResult(ServerHttpRequest request, ServerHttpResponse response,
 			HandlerResult result);
 
 }

--- a/src/main/java/org/springframework/web/reactive/ResponseStatusExceptionHandler.java
+++ b/src/main/java/org/springframework/web/reactive/ResponseStatusExceptionHandler.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.web.reactive;
 
-import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Mono;
 
 import org.springframework.http.server.reactive.HttpExceptionHandler;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -32,12 +31,12 @@ public class ResponseStatusExceptionHandler implements HttpExceptionHandler {
 
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response, Throwable ex) {
+	public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response, Throwable ex) {
 		if (ex instanceof ResponseStatusException) {
 			response.setStatusCode(((ResponseStatusException) ex).getHttpStatus());
-			return Publishers.empty();
+			return Mono.empty();
 		}
-		return Publishers.error(ex);
+		return Mono.error(ex);
 	}
 
 }

--- a/src/main/java/org/springframework/web/reactive/handler/HttpHandlerAdapter.java
+++ b/src/main/java/org/springframework/web/reactive/handler/HttpHandlerAdapter.java
@@ -17,7 +17,7 @@
 package org.springframework.web.reactive.handler;
 
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Mono;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -50,12 +50,12 @@ public class HttpHandlerAdapter implements HandlerAdapter {
 	}
 
 	@Override
-	public Publisher<HandlerResult> handle(ServerHttpRequest request,
+	public Mono<HandlerResult> handle(ServerHttpRequest request,
 			ServerHttpResponse response, Object handler) {
 
 		HttpHandler httpHandler = (HttpHandler)handler;
-		Publisher<Void> completion = httpHandler.handle(request, response);
-		return Publishers.just(new HandlerResult(httpHandler, completion, PUBLISHER_VOID));
+		Mono<Void> completion = httpHandler.handle(request, response);
+		return Mono.just(new HandlerResult(httpHandler, completion, PUBLISHER_VOID));
 	}
 
 }

--- a/src/main/java/org/springframework/web/reactive/handler/SimpleHandlerResultHandler.java
+++ b/src/main/java/org/springframework/web/reactive/handler/SimpleHandlerResultHandler.java
@@ -17,7 +17,7 @@
 package org.springframework.web.reactive.handler;
 
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Mono;
 
 import org.springframework.core.Ordered;
 import org.springframework.core.ResolvableType;
@@ -74,17 +74,17 @@ public class SimpleHandlerResultHandler implements Ordered, HandlerResultHandler
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public Publisher<Void> handleResult(ServerHttpRequest request,
+	public Mono<Void> handleResult(ServerHttpRequest request,
 			ServerHttpResponse response, HandlerResult result) {
 
 		Object value = result.getResult();
 
 		if (Void.TYPE.equals(result.getResultType().getRawClass())) {
-			return Publishers.empty();
+			return Mono.empty();
 		}
 
-		return (value instanceof Publisher ? (Publisher<Void>)value :
-				this.conversionService.convert(value, Publisher.class));
+		return (value instanceof Mono ? (Mono<Void>)value :
+				Mono.from(this.conversionService.convert(value, Publisher.class)));
 	}
 
 }

--- a/src/main/java/org/springframework/web/reactive/handler/SimpleUrlHandlerMapping.java
+++ b/src/main/java/org/springframework/web/reactive/handler/SimpleUrlHandlerMapping.java
@@ -19,8 +19,8 @@ package org.springframework.web.reactive.handler;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.PublisherFactory;
+import reactor.Flux;
+import reactor.Mono;
 
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.reactive.HandlerMapping;
@@ -42,15 +42,15 @@ public class SimpleUrlHandlerMapping implements HandlerMapping {
 
 
 	@Override
-	public Publisher<Object> getHandler(ServerHttpRequest request) {
-		return PublisherFactory.create(subscriber -> {
+	public Mono<Object> getHandler(ServerHttpRequest request) {
+		return Flux.create(subscriber -> {
 			String path = request.getURI().getPath();
 			Object handler = this.handlerMap.get(path);
 			if (handler != null) {
 				subscriber.onNext(handler);
 			}
 			subscriber.onComplete();
-		});
+		}).next();
 	}
 
 }

--- a/src/main/java/org/springframework/web/reactive/method/HandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/web/reactive/method/HandlerMethodArgumentResolver.java
@@ -16,7 +16,7 @@
 
 package org.springframework.web.reactive.method;
 
-import org.reactivestreams.Publisher;
+import reactor.Mono;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -39,6 +39,6 @@ public interface HandlerMethodArgumentResolver {
 	 * resolve to any value which will result in passing {@code null} as the
 	 * argument value.
 	 */
-	Publisher<Object> resolveArgument(MethodParameter parameter, ServerHttpRequest request);
+	Mono<Object> resolveArgument(MethodParameter parameter, ServerHttpRequest request);
 
 }

--- a/src/main/java/org/springframework/web/reactive/method/InvocableHandlerMethod.java
+++ b/src/main/java/org/springframework/web/reactive/method/InvocableHandlerMethod.java
@@ -21,15 +21,13 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
+import reactor.Mono;
 import reactor.fn.tuple.Tuple;
-import reactor.rx.Streams;
 
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.GenericTypeResolver;
@@ -48,7 +46,7 @@ import org.springframework.web.reactive.HandlerResult;
  */
 public class InvocableHandlerMethod extends HandlerMethod {
 
-	public static final Publisher<Object[]> NO_ARGS = Publishers.just(new Object[0]);
+	public static final Mono<Object[]> NO_ARGS = Mono.just(new Object[0]);
 
 	private final static Object NO_VALUE = new Object();
 
@@ -86,38 +84,37 @@ public class InvocableHandlerMethod extends HandlerMethod {
 	 * @return Publisher that produces a single HandlerResult or an error signal;
 	 * never throws an exception.
 	 */
-	public Publisher<HandlerResult> invokeForRequest(ServerHttpRequest request, Object... providedArgs) {
+	public Mono<HandlerResult> invokeForRequest(ServerHttpRequest request, Object... providedArgs) {
 
-		Publisher<Object[]> argsPublisher = NO_ARGS;
+		Mono<Object[]> argsPublisher = NO_ARGS;
 		try {
 			if (!ObjectUtils.isEmpty(getMethodParameters())) {
-				List<Publisher<Object>> publishers = resolveArguments(request, providedArgs);
-				argsPublisher = Publishers.zip(publishers, this::initArgs);
-				argsPublisher = first(argsPublisher);
+				List<Mono<Object>> publishers = resolveArguments(request, providedArgs);
+				argsPublisher = Flux.zip(publishers, this::initArgs).next();
 			}
 		}
 		catch (Throwable ex) {
-			return Publishers.error(ex);
+			return Mono.error(ex);
 		}
 
-		return Publishers.concatMap(argsPublisher, args -> {
+		return Flux.from(argsPublisher).concatMap(args -> {
 			try {
 				Object value = doInvoke(args);
 				ResolvableType type =  ResolvableType.forMethodParameter(getReturnType());
 				HandlerResult handlerResult = new HandlerResult(this, value, type);
-				return Publishers.just(handlerResult);
+				return Mono.just(handlerResult);
 			}
 			catch (InvocationTargetException ex) {
-				return Publishers.error(ex.getTargetException());
+				return Mono.error(ex.getTargetException());
 			}
 			catch (Throwable ex) {
 				String s = getInvocationErrorMessage(args);
-				return Publishers.error(new IllegalStateException(s));
+				return Mono.error(new IllegalStateException(s));
 			}
-		});
+		}).next();
 	}
 
-	private List<Publisher<Object>> resolveArguments(ServerHttpRequest request, Object... providedArgs) {
+	private List<Mono<Object>> resolveArguments(ServerHttpRequest request, Object... providedArgs) {
 		return Stream.of(getMethodParameters())
 				.map(parameter -> {
 					parameter.initParameterNameDiscovery(this.parameterNameDiscoverer);
@@ -125,7 +122,7 @@ public class InvocableHandlerMethod extends HandlerMethod {
 					if (!ObjectUtils.isEmpty(providedArgs)) {
 						for (Object providedArg : providedArgs) {
 							if (parameter.getParameterType().isInstance(providedArg)) {
-								return Publishers.just(providedArg);
+								return Mono.just(providedArg);
 							}
 						}
 					}
@@ -134,9 +131,10 @@ public class InvocableHandlerMethod extends HandlerMethod {
 							.findFirst()
 							.orElseThrow(() -> getArgError("No resolver for ", parameter, null));
 					try {
-						Publisher<Object> publisher = resolver.resolveArgument(parameter, request);
-						publisher = mapError(publisher, ex -> getArgError("Error resolving ", parameter, ex));
-						return Streams.wrap(publisher).defaultIfEmpty(NO_VALUE);
+						return resolver.resolveArgument(parameter, request)
+								// TODO Add a defaultIfEmpty alias to Mono to avoid conversion to Flux
+								.flux().defaultIfEmpty(NO_VALUE).next()
+								.otherwise(ex -> Mono.error(getArgError("Error resolving ", parameter, ex)));
 					}
 					catch (Exception ex) {
 						throw getArgError("Error resolving ", parameter, ex);
@@ -178,19 +176,6 @@ public class InvocableHandlerMethod extends HandlerMethod {
 
 	private Object[] initArgs(Tuple tuple) {
 		return Stream.of(tuple.toArray()).map(o -> o != NO_VALUE ? o : null).toArray();
-	}
-
-
-	private static <E> Publisher<E> first(Publisher<E> source) {
-		return Publishers.lift(source, (e, subscriber) -> {
-			subscriber.onNext(e);
-			subscriber.onComplete();
-		});
-	}
-
-	private static <E> Publisher<E> mapError(Publisher<E> source, Function<Throwable, Throwable> function) {
-		return Publishers.lift(source, null,
-				(throwable, subscriber) -> subscriber.onError(function.apply(throwable)), null);
 	}
 
 }

--- a/src/main/java/org/springframework/web/reactive/method/annotation/RequestMappingHandlerMapping.java
+++ b/src/main/java/org/springframework/web/reactive/method/annotation/RequestMappingHandlerMapping.java
@@ -27,8 +27,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.PublisherFactory;
+import reactor.Flux;
+import reactor.Mono;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
@@ -94,8 +94,8 @@ public class RequestMappingHandlerMapping implements HandlerMapping,
 	}
 
 	@Override
-	public Publisher<Object> getHandler(ServerHttpRequest request) {
-		return PublisherFactory.create(subscriber -> {
+	public Mono<Object> getHandler(ServerHttpRequest request) {
+		return Flux.create(subscriber -> {
 			for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : this.methodMap.entrySet()) {
 				RequestMappingInfo info = entry.getKey();
 				if (info.matchesRequest(request)) {
@@ -109,7 +109,7 @@ public class RequestMappingHandlerMapping implements HandlerMapping,
 				}
 			}
 			subscriber.onComplete();
-		});
+		}).next();
 	}
 
 

--- a/src/main/java/org/springframework/web/reactive/method/annotation/RequestParamArgumentResolver.java
+++ b/src/main/java/org/springframework/web/reactive/method/annotation/RequestParamArgumentResolver.java
@@ -16,11 +16,7 @@
 
 package org.springframework.web.reactive.method.annotation;
 
-
-import java.util.Optional;
-
-import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Mono;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -45,12 +41,12 @@ public class RequestParamArgumentResolver implements HandlerMethodArgumentResolv
 
 
 	@Override
-	public Publisher<Object> resolveArgument(MethodParameter param, ServerHttpRequest request) {
+	public Mono<Object> resolveArgument(MethodParameter param, ServerHttpRequest request) {
 		RequestParam annotation = param.getParameterAnnotation(RequestParam.class);
 		String name = (annotation.value().length() != 0 ? annotation.value() : param.getParameterName());
 		UriComponents uriComponents = UriComponentsBuilder.fromUri(request.getURI()).build();
 		String value = uriComponents.getQueryParams().getFirst(name);
-		return (value != null ? Publishers.just(value) : Publishers.empty());
+		return (value != null ? Mono.just(value) : Mono.empty());
 	}
 
 }

--- a/src/main/java/org/springframework/web/reactive/method/annotation/ResponseBodyResultHandler.java
+++ b/src/main/java/org/springframework/web/reactive/method/annotation/ResponseBodyResultHandler.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Mono;
 
 import org.springframework.core.Ordered;
 import org.springframework.core.ResolvableType;
@@ -127,12 +127,12 @@ public class ResponseBodyResultHandler implements HandlerResultHandler, Ordered 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Publisher<Void> handleResult(ServerHttpRequest request,
+	public Mono<Void> handleResult(ServerHttpRequest request,
 			ServerHttpResponse response, HandlerResult result) {
 
 		Object value = result.getResult();
 		if (value == null) {
-			return Publishers.empty();
+			return Mono.empty();
 		}
 
 		Publisher<?> publisher;
@@ -143,7 +143,7 @@ public class ResponseBodyResultHandler implements HandlerResultHandler, Ordered 
 			elementType = returnType.getGeneric(0);
 		}
 		else {
-			publisher = Publishers.just(value);
+			publisher = Mono.just(value);
 			elementType = returnType;
 		}
 
@@ -163,7 +163,7 @@ public class ResponseBodyResultHandler implements HandlerResultHandler, Ordered 
 			}
 		}
 		if (compatibleMediaTypes.isEmpty()) {
-			return Publishers.error(new HttpMediaTypeNotAcceptableException(producibleMediaTypes));
+			return Mono.error(new HttpMediaTypeNotAcceptableException(producibleMediaTypes));
 		}
 
 		List<MediaType> mediaTypes = new ArrayList<>(compatibleMediaTypes);
@@ -189,7 +189,7 @@ public class ResponseBodyResultHandler implements HandlerResultHandler, Ordered 
 			}
 		}
 
-		return Publishers.error(new HttpMediaTypeNotAcceptableException(this.allMediaTypes));
+		return Mono.error(new HttpMediaTypeNotAcceptableException(this.allMediaTypes));
 	}
 
 	private List<MediaType> getAcceptableMediaTypes(ServerHttpRequest request) {

--- a/src/test/java/org/springframework/http/server/reactive/EchoHandler.java
+++ b/src/test/java/org/springframework/http/server/reactive/EchoHandler.java
@@ -16,11 +16,7 @@
 
 package org.springframework.http.server.reactive;
 
-import org.reactivestreams.Publisher;
-
-import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
+import reactor.Mono;
 
 /**
  * @author Arjen Poutsma
@@ -28,7 +24,7 @@ import org.springframework.http.server.reactive.ServerHttpResponse;
 public class EchoHandler implements HttpHandler {
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+	public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 		return response.setBody(request.getBody());
 	}
 }

--- a/src/test/java/org/springframework/http/server/reactive/MockServerHttpRequest.java
+++ b/src/test/java/org/springframework/http/server/reactive/MockServerHttpRequest.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 
 import org.reactivestreams.Publisher;
+import reactor.Flux;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -34,7 +35,7 @@ public class MockServerHttpRequest implements ServerHttpRequest {
 
 	private HttpHeaders headers = new HttpHeaders();
 
-	private Publisher<ByteBuffer> body;
+	private Flux<ByteBuffer> body;
 
 
 	public MockServerHttpRequest(HttpMethod httpMethod, URI uri) {
@@ -43,7 +44,7 @@ public class MockServerHttpRequest implements ServerHttpRequest {
 	}
 
 	public MockServerHttpRequest(Publisher<ByteBuffer> body, HttpMethod httpMethod, URI uri) {
-		this.body = body;
+		this.body = Flux.from(body);
 		this.httpMethod = httpMethod;
 		this.uri = uri;
 	}
@@ -77,11 +78,11 @@ public class MockServerHttpRequest implements ServerHttpRequest {
 	}
 
 	@Override
-	public Publisher<ByteBuffer> getBody() {
+	public Flux<ByteBuffer> getBody() {
 		return this.body;
 	}
 
 	public void setBody(Publisher<ByteBuffer> body) {
-		this.body = body;
+		this.body = Flux.from(body);
 	}
 }

--- a/src/test/java/org/springframework/http/server/reactive/MockServerHttpResponse.java
+++ b/src/test/java/org/springframework/http/server/reactive/MockServerHttpResponse.java
@@ -18,7 +18,8 @@ package org.springframework.http.server.reactive;
 import java.nio.ByteBuffer;
 
 import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Flux;
+import reactor.Mono;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -50,9 +51,9 @@ public class MockServerHttpResponse implements ServerHttpResponse {
 	}
 
 	@Override
-	public Publisher<Void> setBody(Publisher<ByteBuffer> body) {
+	public Mono<Void> setBody(Publisher<ByteBuffer> body) {
 		this.body = body;
-		return Publishers.concatMap(body, b -> Publishers.empty());
+		return Flux.from(body).after();
 	}
 
 	public Publisher<ByteBuffer> getBody() {

--- a/src/test/java/org/springframework/http/server/reactive/RandomHandler.java
+++ b/src/test/java/org/springframework/http/server/reactive/RandomHandler.java
@@ -21,11 +21,10 @@ import java.util.Random;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.Mono;
 import reactor.io.buffer.Buffer;
-import reactor.rx.Streams;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,7 +40,7 @@ public class RandomHandler implements HttpHandler {
 	private final Random rnd = new Random();
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+	public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 
 		request.getBody().subscribe(new Subscriber<ByteBuffer>() {
 			private Subscription s;
@@ -73,7 +72,7 @@ public class RandomHandler implements HttpHandler {
 		});
 
 		response.getHeaders().setContentLength(RESPONSE_SIZE);
-		return response.setBody(Streams.just(ByteBuffer.wrap(randomBytes())));
+		return response.setBody(Mono.just(ByteBuffer.wrap(randomBytes())));
 	}
 
 	private byte[] randomBytes() {

--- a/src/test/java/org/springframework/http/server/reactive/XmlHandler.java
+++ b/src/test/java/org/springframework/http/server/reactive/XmlHandler.java
@@ -22,7 +22,7 @@ import javax.xml.bind.Unmarshaller;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.reactivestreams.Publisher;
+import reactor.Mono;
 import reactor.io.buffer.Buffer;
 import reactor.rx.Streams;
 
@@ -40,7 +40,7 @@ public class XmlHandler implements HttpHandler {
 	private static final Log logger = LogFactory.getLog(XmlHandler.class);
 
 	@Override
-	public Publisher<Void> handle(ServerHttpRequest request,
+	public Mono<Void> handle(ServerHttpRequest request,
 			ServerHttpResponse response) {
 		try {
 			JAXBContext jaxbContext = JAXBContext.newInstance(XmlHandlerIntegrationTests.Person.class);

--- a/src/test/java/org/springframework/reactive/codec/decoder/ByteBufferDecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/ByteBufferDecoderTests.java
@@ -49,8 +49,8 @@ public class ByteBufferDecoderTests {
 		ByteBuffer fooBuffer = Buffer.wrap("foo").byteBuffer();
 		ByteBuffer barBuffer = Buffer.wrap("bar").byteBuffer();
 		Stream<ByteBuffer> source = Streams.just(fooBuffer, barBuffer);
-		List<ByteBuffer> results = Streams.wrap(decoder.decode(source,
-				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class), null)).toList().await();
+		List<ByteBuffer> results = Streams.from(decoder.decode(source,
+				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class), null)).toList().get();
 		assertEquals(2, results.size());
 		assertEquals(fooBuffer, results.get(0));
 		assertEquals(barBuffer, results.get(1));

--- a/src/test/java/org/springframework/reactive/codec/decoder/JacksonJsonDecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/JacksonJsonDecoderTests.java
@@ -48,8 +48,8 @@ public class JacksonJsonDecoderTests {
 	@Test
 	public void decode() throws InterruptedException {
 		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer());
-		List<Object> results = Streams.wrap(decoder.decode(source, ResolvableType.forClass(Pojo.class), null))
-				.toList().await();
+		List<Object> results = Streams.from(decoder.decode(source, ResolvableType.forClass(Pojo.class), null))
+				.toList().get();
 		assertEquals(1, results.size());
 		assertEquals("foofoo", ((Pojo) results.get(0)).getFoo());
 	}

--- a/src/test/java/org/springframework/reactive/codec/decoder/Jaxb2DecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/Jaxb2DecoderTests.java
@@ -49,8 +49,8 @@ public class Jaxb2DecoderTests {
 	@Test
 	public void decode() throws InterruptedException {
 		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("<?xml version=\"1.0\" encoding=\"UTF-8\"?><pojo><bar>barbar</bar><foo>foofoo</foo></pojo>").byteBuffer());
-		List<Object> results = Streams.wrap(decoder.decode(source, ResolvableType.forClass(Pojo.class), null))
-				.toList().await();
+		List<Object> results = Streams.from(decoder.decode(source, ResolvableType.forClass(Pojo.class), null))
+				.toList().get();
 		assertEquals(1, results.size());
 		assertEquals("foofoo", ((Pojo) results.get(0)).getFoo());
 	}

--- a/src/test/java/org/springframework/reactive/codec/decoder/JsonObjectDecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/JsonObjectDecoderTests.java
@@ -37,11 +37,11 @@ public class JsonObjectDecoderTests {
 	public void decodeSingleChunkToJsonObject() throws InterruptedException {
 		JsonObjectDecoder decoder = new JsonObjectDecoder();
 		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer());
-		List<String> results = Streams.wrap(decoder.decode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(decoder.decode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
 					return new String(b, StandardCharsets.UTF_8);
-				}).toList().await();
+				}).toList().get();
 		assertEquals(1, results.size());
 		assertEquals("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}", results.get(0));
 	}
@@ -50,11 +50,11 @@ public class JsonObjectDecoderTests {
 	public void decodeMultipleChunksToJsonObject() throws InterruptedException {
 		JsonObjectDecoder decoder = new JsonObjectDecoder();
 		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("{\"foo\": \"foofoo\"").byteBuffer(), Buffer.wrap(", \"bar\": \"barbar\"}").byteBuffer());
-		List<String> results = Streams.wrap(decoder.decode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(decoder.decode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
 					return new String(b, StandardCharsets.UTF_8);
-				}).toList().await();
+				}).toList().get();
 		assertEquals(1, results.size());
 		assertEquals("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}", results.get(0));
 	}
@@ -63,11 +63,11 @@ public class JsonObjectDecoderTests {
 	public void decodeSingleChunkToArray() throws InterruptedException {
 		JsonObjectDecoder decoder = new JsonObjectDecoder();
 		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("[{\"foo\": \"foofoo\", \"bar\": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]").byteBuffer());
-		List<String> results = Streams.wrap(decoder.decode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(decoder.decode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
 					return new String(b, StandardCharsets.UTF_8);
-				}).toList().await();
+				}).toList().get();
 		assertEquals(2, results.size());
 		assertEquals("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}", results.get(0));
 		assertEquals("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}", results.get(1));
@@ -77,11 +77,11 @@ public class JsonObjectDecoderTests {
 	public void decodeMultipleChunksToArray() throws InterruptedException {
 		JsonObjectDecoder decoder = new JsonObjectDecoder();
 		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("[{\"foo\": \"foofoo\", \"bar\"").byteBuffer(), Buffer.wrap(": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]").byteBuffer());
-		List<String> results = Streams.wrap(decoder.decode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(decoder.decode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
 					return new String(b, StandardCharsets.UTF_8);
-				}).toList().await();
+				}).toList().get();
 		assertEquals(2, results.size());
 		assertEquals("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}", results.get(0));
 		assertEquals("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}", results.get(1));

--- a/src/test/java/org/springframework/reactive/codec/decoder/StringDecoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/decoder/StringDecoderTests.java
@@ -49,8 +49,8 @@ public class StringDecoderTests {
 	@Test
 	public void decode() throws InterruptedException {
 		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("foo").byteBuffer(), Buffer.wrap("bar").byteBuffer());
-		List<String> results = Streams.wrap(decoder.decode(source,
-				ResolvableType.forClassWithGenerics(Publisher.class, String.class), null)).toList().await();
+		List<String> results = Streams.from(decoder.decode(source,
+				ResolvableType.forClassWithGenerics(Publisher.class, String.class), null)).toList().get();
 		assertEquals(2, results.size());
 		assertEquals("foo", results.get(0));
 		assertEquals("bar", results.get(1));

--- a/src/test/java/org/springframework/reactive/codec/encoder/ByteBufferEncoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/encoder/ByteBufferEncoderTests.java
@@ -49,8 +49,8 @@ public class ByteBufferEncoderTests {
 		ByteBuffer fooBuffer = Buffer.wrap("foo").byteBuffer();
 		ByteBuffer barBuffer = Buffer.wrap("bar").byteBuffer();
 		Stream<ByteBuffer> source = Streams.just(fooBuffer, barBuffer);
-		List<ByteBuffer> results = Streams.wrap(encoder.encode(source,
-				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class), null)).toList().await();
+		List<ByteBuffer> results = Streams.from(encoder.encode(source,
+				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class), null)).toList().get();
 		assertEquals(2, results.size());
 		assertEquals(fooBuffer, results.get(0));
 		assertEquals(barBuffer, results.get(1));

--- a/src/test/java/org/springframework/reactive/codec/encoder/JacksonJsonEncoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/encoder/JacksonJsonEncoderTests.java
@@ -46,11 +46,11 @@ public class JacksonJsonEncoderTests {
 	@Test
 	public void write() throws InterruptedException {
 		Stream<Pojo> source = Streams.just(new Pojo("foofoo", "barbar"), new Pojo("foofoofoo", "barbarbar"));
-		List<String> results = Streams.wrap(encoder.encode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(encoder.encode(source, null, null)).map(chunk -> {
 			byte[] b = new byte[chunk.remaining()];
 			chunk.get(b);
 			return new String(b, StandardCharsets.UTF_8);
-		}).toList().await();
+		}).toList().get();
 		assertEquals(2, results.size());
 		assertEquals("{\"foo\":\"foofoo\",\"bar\":\"barbar\"}", results.get(0));
 		assertEquals("{\"foo\":\"foofoofoo\",\"bar\":\"barbarbar\"}", results.get(1));

--- a/src/test/java/org/springframework/reactive/codec/encoder/Jaxb2EncoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/encoder/Jaxb2EncoderTests.java
@@ -47,11 +47,11 @@ public class Jaxb2EncoderTests {
 	@Test
 	public void encode() throws InterruptedException {
 		Stream<Pojo> source = Streams.just(new Pojo("foofoo", "barbar"), new Pojo("foofoofoo", "barbarbar"));
-		List<String> results = Streams.wrap(encoder.encode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(encoder.encode(source, null, null)).map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
 					return new String(b, StandardCharsets.UTF_8);
-				}).toList().await();
+				}).toList().get();
 		assertEquals(2, results.size());
 		assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><pojo><bar>barbar</bar><foo>foofoo</foo></pojo>", results.get(0));
 		assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><pojo><bar>barbarbar</bar><foo>foofoofoo</foo></pojo>", results.get(1));

--- a/src/test/java/org/springframework/reactive/codec/encoder/JsonObjectEncoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/encoder/JsonObjectEncoderTests.java
@@ -37,11 +37,11 @@ public class JsonObjectEncoderTests {
 	public void encodeSingleElement() throws InterruptedException {
 		JsonObjectEncoder encoder = new JsonObjectEncoder();
 		Stream<ByteBuffer> source = Streams.just(Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer());
-		List<String> results = Streams.wrap(encoder.encode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(encoder.encode(source, null, null)).map(chunk -> {
 			byte[] b = new byte[chunk.remaining()];
 			chunk.get(b);
 			return new String(b, StandardCharsets.UTF_8);
-		}).toList().await();
+		}).toList().get();
 		String result = String.join("", results);
 		assertEquals("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}", result);
 	}
@@ -52,11 +52,11 @@ public class JsonObjectEncoderTests {
 		Stream<ByteBuffer> source = Streams.just(
 				Buffer.wrap("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}").byteBuffer(),
 				Buffer.wrap("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}").byteBuffer());
-		List<String> results = Streams.wrap(encoder.encode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(encoder.encode(source, null, null)).map(chunk -> {
 			byte[] b = new byte[chunk.remaining()];
 			chunk.get(b);
 			return new String(b, StandardCharsets.UTF_8);
-		}).toList().await();
+		}).toList().get();
 		String result = String.join("", results);
 		assertEquals("[{\"foo\": \"foofoo\", \"bar\": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]", result);
 	}
@@ -69,11 +69,11 @@ public class JsonObjectEncoderTests {
 				Buffer.wrap("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}").byteBuffer(),
 				Buffer.wrap("{\"foo\": \"foofoofoofoo\", \"bar\": \"barbarbarbar\"}").byteBuffer()
 		);
-		List<String> results = Streams.wrap(encoder.encode(source, null, null)).map(chunk -> {
+		List<String> results = Streams.from(encoder.encode(source, null, null)).map(chunk -> {
 			byte[] b = new byte[chunk.remaining()];
 			chunk.get(b);
 			return new String(b, StandardCharsets.UTF_8);
-		}).toList().await();
+		}).toList().get();
 		String result = String.join("", results);
 		assertEquals("[{\"foo\": \"foofoo\", \"bar\": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"},{\"foo\": \"foofoofoofoo\", \"bar\": \"barbarbarbar\"}]", result);
 	}

--- a/src/test/java/org/springframework/reactive/codec/encoder/StringEncoderTests.java
+++ b/src/test/java/org/springframework/reactive/codec/encoder/StringEncoderTests.java
@@ -45,12 +45,12 @@ public class StringEncoderTests {
 
 	@Test
 	public void write() throws InterruptedException {
-		List<String> results = Streams.wrap(encoder.encode(Streams.just("foo"), null, null))
+		List<String> results = Streams.from(encoder.encode(Streams.just("foo"), null, null))
 				.map(chunk -> {
 					byte[] b = new byte[chunk.remaining()];
 					chunk.get(b);
 					return new String(b, StandardCharsets.UTF_8);
-				}).toList().await();
+				}).toList().get();
 		assertEquals(1, results.size());
 		assertEquals("foo", results.get(0));
 	}

--- a/src/test/java/org/springframework/web/reactive/ResponseStatusExceptionHandlerTests.java
+++ b/src/test/java/org/springframework/web/reactive/ResponseStatusExceptionHandlerTests.java
@@ -60,7 +60,7 @@ public class ResponseStatusExceptionHandlerTests {
 		Throwable ex = new ResponseStatusException(HttpStatus.BAD_REQUEST);
 		Publisher<Void> publisher = this.handler.handle(this.request, this.response, ex);
 
-		Streams.wrap(publisher).toList().await(5, TimeUnit.SECONDS);
+		Streams.from(publisher).toList().get();
 		assertEquals(HttpStatus.BAD_REQUEST, this.response.getStatus());
 	}
 
@@ -69,7 +69,7 @@ public class ResponseStatusExceptionHandlerTests {
 		Throwable ex = new IllegalStateException();
 		Publisher<Void> publisher = this.handler.handle(this.request, this.response, ex);
 
-		List<Signal<Void>> signals = Streams.wrap(publisher).materialize().toList().await(5, TimeUnit.SECONDS);
+		List<Signal<Void>> signals = Streams.from(publisher).materialize().toList().get();
 		assertEquals(1, signals.size());
 		assertTrue(signals.get(0).hasError());
 		assertSame(ex, signals.get(0).getThrowable());

--- a/src/test/java/org/springframework/web/reactive/handler/SimpleHandlerResultHandlerTests.java
+++ b/src/test/java/org/springframework/web/reactive/handler/SimpleHandlerResultHandlerTests.java
@@ -28,7 +28,7 @@ import rx.Observable;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.core.convert.support.ReactiveStreamsToCompletableFutureConverter;
-import org.springframework.core.convert.support.ReactiveStreamsToReactorConverter;
+import org.springframework.core.convert.support.ReactiveStreamsToReactorStreamConverter;
 import org.springframework.core.convert.support.ReactiveStreamsToRxJava1Converter;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.reactive.HandlerResult;
@@ -75,7 +75,7 @@ public class SimpleHandlerResultHandlerTests {
 
 		GenericConversionService conversionService = new GenericConversionService();
 		conversionService.addConverter(new ReactiveStreamsToCompletableFutureConverter());
-		conversionService.addConverter(new ReactiveStreamsToReactorConverter());
+		conversionService.addConverter(new ReactiveStreamsToReactorStreamConverter());
 		conversionService.addConverter(new ReactiveStreamsToRxJava1Converter());
 		SimpleHandlerResultHandler resultHandler = new SimpleHandlerResultHandler(conversionService);
 		TestController controller = new TestController();

--- a/src/test/java/org/springframework/web/reactive/handler/SimpleUrlHandlerMappingIntegrationTests.java
+++ b/src/test/java/org/springframework/web/reactive/handler/SimpleUrlHandlerMappingIntegrationTests.java
@@ -22,8 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
-import org.reactivestreams.Publisher;
-import reactor.Publishers;
+import reactor.Mono;
 import reactor.io.buffer.Buffer;
 import reactor.rx.Streams;
 
@@ -136,7 +135,7 @@ public class SimpleUrlHandlerMappingIntegrationTests extends AbstractHttpHandler
 	private static class FooHandler implements HttpHandler {
 
 		@Override
-		public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+		public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 			return response.setBody(Streams.just(Buffer.wrap("foo").byteBuffer()));
 		}
 	}
@@ -144,7 +143,7 @@ public class SimpleUrlHandlerMappingIntegrationTests extends AbstractHttpHandler
 	private static class BarHandler implements HttpHandler {
 
 		@Override
-		public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+		public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 			return response.setBody(Streams.just(Buffer.wrap("bar").byteBuffer()));
 		}
 	}
@@ -152,9 +151,9 @@ public class SimpleUrlHandlerMappingIntegrationTests extends AbstractHttpHandler
 	private static class HeaderSettingHandler implements HttpHandler {
 
 		@Override
-		public Publisher<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+		public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 			response.getHeaders().add("foo", "bar");
-			return Publishers.empty();
+			return Mono.empty();
 		}
 	}
 

--- a/src/test/java/org/springframework/web/reactive/method/annotation/RequestMappingHandlerMappingTests.java
+++ b/src/test/java/org/springframework/web/reactive/method/annotation/RequestMappingHandlerMappingTests.java
@@ -18,7 +18,6 @@ package org.springframework.web.reactive.method.annotation;
 
 import java.net.URI;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -78,7 +77,7 @@ public class RequestMappingHandlerMappingTests {
 
 	private HandlerMethod toHandlerMethod(Publisher<?> handlerPublisher) throws InterruptedException {
 		assertNotNull(handlerPublisher);
-		List<?> handlerList = Streams.wrap(handlerPublisher).toList().await(5, TimeUnit.SECONDS);
+		List<?> handlerList = Streams.from(handlerPublisher).toList().get();
 		assertEquals(1, handlerList.size());
 		return (HandlerMethod) handlerList.get(0);
 	}


### PR DESCRIPTION
PR for discussing the design of the 3 "`Publisher` with basic operators" we should provide for Spring projects for return types and implementation use cases:
- [`Flux`](https://github.com/sdeleuze/spring-reactive/blob/transformable-publisher/src/main/java/org/springframework/rx/Flux.java) for multiple values `Publisher` (issue #48)
- [`Promise`](https://github.com/sdeleuze/spring-reactive/blob/transformable-publisher/src/main/java/org/springframework/rx/Promise.java) for single value `Publisher` (issue #50)
- [`Signal`](https://github.com/sdeleuze/spring-reactive/blob/transformable-publisher/src/main/java/org/springframework/rx/Signal.java) for `Publisher` with no value (issue #49) 

Default implementation is based on Reactor Core and not complete, class names could obviously change. This PR in it current status is here to discuss the scope and and design of the API we could provide.