### PR TITLE
Use CharsetDecoder to decode a DataBuffer into a String.

### DIFF
--- a/src/main/java/org/springframework/core/codec/support/StringDecoder.java
+++ b/src/main/java/org/springframework/core/codec/support/StringDecoder.java
@@ -45,7 +45,6 @@ import org.springframework.util.MimeType;
 public class StringDecoder extends AbstractDecoder<String> {
 
 	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
-	public static final String EMPTY = "";
 
 	private final boolean reduceToSingleBuffer;
 
@@ -85,11 +84,6 @@ public class StringDecoder extends AbstractDecoder<String> {
 		}
 		Charset charset = getCharset(mimeType);
 		return inputFlux.map(content -> {
-			// fast-path exit.
-			if(content.readableByteCount() == 0) {
-				return EMPTY;
-			}
-
 			CharBuffer charBuffer = charset.decode(content.asByteBuffer());
 			return charBuffer.toString();
 		});

--- a/src/test/java/org/springframework/core/codec/support/StringDecoderTests.java
+++ b/src/test/java/org/springframework/core/codec/support/StringDecoderTests.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.*;
 /**
  * @author Sebastien Deleuze
  * @author Brian Clozel
+ * @author Mark Paluch
  */
 public class StringDecoderTests extends AbstractAllocatingTestCase {
 
@@ -90,6 +91,16 @@ public class StringDecoderTests extends AbstractAllocatingTestCase {
 				MediaType.TEXT_PLAIN));
 		String result = single.toBlocking().value();
 		assertEquals("foobar", result);
+	}
+
+	@Test
+	public void decodeEmpty() throws InterruptedException {
+		Flux<DataBuffer> source = Flux.just(stringBuffer(""));
+		Single<String> single = RxJava1SingleConverter.from(this.decoder.decode(source,
+				ResolvableType.forClassWithGenerics(Single.class, String.class),
+				MediaType.TEXT_PLAIN));
+		String result = single.toBlocking().value();
+		assertEquals("", result);
 	}
 
 }

--- a/src/test/java/org/springframework/core/codec/support/StringDecoderTests.java
+++ b/src/test/java/org/springframework/core/codec/support/StringDecoderTests.java
@@ -95,12 +95,11 @@ public class StringDecoderTests extends AbstractAllocatingTestCase {
 
 	@Test
 	public void decodeEmpty() throws InterruptedException {
-		Flux<DataBuffer> source = Flux.just(stringBuffer(""));
-		Single<String> single = RxJava1SingleConverter.from(this.decoder.decode(source,
-				ResolvableType.forClassWithGenerics(Single.class, String.class),
-				MediaType.TEXT_PLAIN));
-		String result = single.toBlocking().value();
-		assertEquals("", result);
+		Mono<DataBuffer> source = Mono.just(stringBuffer(""));
+		Flux<String> output =
+				this.decoder.decode(source, ResolvableType.forClass(String.class), null);
+		TestSubscriber<String> testSubscriber = new TestSubscriber<>();
+		testSubscriber.bindTo(output).assertValues("");
 	}
 
 }


### PR DESCRIPTION
This commit uses the internal `ByteBuffer` with `CharsetDecoder` to avoid `byte[]` allocation and a fast-path if the buffer is empty.

In general: String encoding/decoding could be optimized further but it would require thread-local caching of `CharsetEncoder`, `CharBuffer` and some other tweaks (see Netty `ByteBufUtil.encodeString`). 