### PR TITLE
Add Server-Sent Events support

### DIFF
--- a/src/main/java/org/springframework/core/codec/support/SseEventEncoder.java
+++ b/src/main/java/org/springframework/core/codec/support/SseEventEncoder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.codec.support;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.CodecException;
+import org.springframework.core.codec.Encoder;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.FlushingDataBuffer;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeType;
+import org.springframework.web.reactive.sse.SseEvent;
+
+/**
+ * An encoder for {@link SseEvent}s that also supports any other kind of {@link Object}
+ * (in that case, the object will be the data of the {@link SseEvent}).
+ * @author Sebastien Deleuze
+ */
+public class SseEventEncoder extends AbstractEncoder<Object> {
+
+	private final Encoder<String> stringEncoder;
+
+	private final List<Encoder<?>> dataEncoders;
+
+
+	public SseEventEncoder(Encoder<String> stringEncoder, List<Encoder<?>> dataEncoders) {
+		super(new MimeType("text", "event-stream"));
+		Assert.notNull(stringEncoder, "'stringEncoder' must not be null");
+		Assert.notNull(dataEncoders, "'dataEncoders' must not be null");
+		this.stringEncoder = stringEncoder;
+		this.dataEncoders = dataEncoders;
+	}
+
+	@Override
+	public Flux<DataBuffer> encode(Publisher<?> inputStream, DataBufferFactory bufferFactory, ResolvableType type, MimeType sseMimeType, Object... hints) {
+
+		return Flux.from(inputStream).flatMap(input -> {
+			SseEvent event = (SseEvent.class.equals(type.getRawClass()) ? (SseEvent)input : new SseEvent(input));
+
+			StringBuilder sb = new StringBuilder();
+
+			if (event.getId() != null) {
+				sb.append("id:");
+				sb.append(event.getId());
+				sb.append("\n");
+			}
+
+			if (event.getName() != null) {
+				sb.append("event:");
+				sb.append(event.getName());
+				sb.append("\n");
+			}
+
+			if (event.getReconnectTime() != null) {
+				sb.append("retry:");
+				sb.append(event.getReconnectTime().toString());
+				sb.append("\n");
+			}
+
+			if (event.getComment() != null) {
+				sb.append(":");
+				sb.append(event.getComment().replaceAll("\\n", "\n:"));
+				sb.append("\n");
+			}
+
+			Object data = event.getData();
+			Flux<DataBuffer> dataBuffer = Flux.empty();
+			MimeType stringMimeType = this.stringEncoder.getEncodableMimeTypes().get(0);
+			MimeType mimeType = (event.getMimeType() == null ?
+	                (data instanceof String ? stringMimeType : new MimeType("*")) : event.getMimeType());
+			if (data != null) {
+				sb.append("data:");
+				if (data instanceof String && mimeType.isCompatibleWith(stringMimeType)) {
+					sb.append(((String)data).replaceAll("\\n", "\ndata:")).append("\n");
+				}
+				else {
+					Optional<Encoder<?>> encoder = dataEncoders
+						.stream()
+						.filter(e -> e.canEncode(ResolvableType.forClass(data.getClass()), mimeType))
+						.findFirst();
+
+					if (encoder.isPresent()) {
+						dataBuffer = ((Encoder<Object>)encoder.get())
+								.encode(Mono.just(data), bufferFactory, ResolvableType.forClass(data.getClass()), mimeType)
+								.concatWith(encodeString("\n", bufferFactory, stringMimeType));
+					}
+					else {
+						throw new CodecException("No suitable encoder found!");
+					}
+				}
+			}
+
+			return Flux
+					.concat(encodeString(sb.toString(), bufferFactory, stringMimeType), dataBuffer)
+					.reduce((buf1, buf2) -> buf1.write(buf2))
+					.concatWith(encodeString("\n", bufferFactory, stringMimeType).map(b -> new FlushingDataBuffer(b)));
+		});
+
+	}
+
+	private Flux<DataBuffer> encodeString(String str, DataBufferFactory bufferFactory, MimeType mimeType) {
+		return stringEncoder.encode(Mono.just(str), bufferFactory, ResolvableType.forClass(String.class), mimeType);
+	}
+
+}

--- a/src/main/java/org/springframework/core/io/buffer/FlushingDataBuffer.java
+++ b/src/main/java/org/springframework/core/io/buffer/FlushingDataBuffer.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.io.buffer;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.function.IntPredicate;
+
+import org.springframework.util.Assert;
+
+/**
+ * {@link DataBuffer} wrapper that indicates the file or the socket writing this buffer
+ * should be flushed.
+ *
+ * @author Sebastien Deleuze
+ */
+public class FlushingDataBuffer implements DataBuffer {
+
+	private final DataBuffer buffer;
+
+	public FlushingDataBuffer(DataBuffer buffer) {
+		Assert.notNull(buffer);
+		this.buffer = buffer;
+	}
+
+	@Override
+	public DataBufferFactory factory() {
+		return this.buffer.factory();
+	}
+
+	@Override
+	public int indexOf(IntPredicate predicate, int fromIndex) {
+		return this.buffer.indexOf(predicate, fromIndex);
+	}
+
+	@Override
+	public int lastIndexOf(IntPredicate predicate, int fromIndex) {
+		return this.buffer.lastIndexOf(predicate, fromIndex);
+	}
+
+	@Override
+	public int readableByteCount() {
+		return this.buffer.readableByteCount();
+	}
+
+	@Override
+	public byte read() {
+		return this.buffer.read();
+	}
+
+	@Override
+	public DataBuffer read(byte[] destination) {
+		return this.buffer.read(destination);
+	}
+
+	@Override
+	public DataBuffer read(byte[] destination, int offset, int length) {
+		return this.buffer.read(destination, offset, length);
+	}
+
+	@Override
+	public DataBuffer write(byte b) {
+		return this.buffer.write(b);
+	}
+
+	@Override
+	public DataBuffer write(byte[] source) {
+		return this.buffer.write(source);
+	}
+
+	@Override
+	public DataBuffer write(byte[] source, int offset, int length) {
+		return this.write(source, offset, length);
+	}
+
+	@Override
+	public DataBuffer write(DataBuffer... buffers) {
+		return this.buffer.write(buffers);
+	}
+
+	@Override
+	public DataBuffer write(ByteBuffer... buffers) {
+		return this.buffer.write(buffers);
+	}
+
+	@Override
+	public DataBuffer slice(int index, int length) {
+		return this.buffer.slice(index, length);
+	}
+
+	@Override
+	public ByteBuffer asByteBuffer() {
+		return this.buffer.asByteBuffer();
+	}
+
+	@Override
+	public InputStream asInputStream() {
+		return this.buffer.asInputStream();
+	}
+
+	@Override
+	public OutputStream asOutputStream() {
+		return this.buffer.asOutputStream();
+	}
+}

--- a/src/main/java/org/springframework/core/io/buffer/FlushingDataBuffer.java
+++ b/src/main/java/org/springframework/core/io/buffer/FlushingDataBuffer.java
@@ -33,6 +33,10 @@ public class FlushingDataBuffer implements DataBuffer {
 
 	private final DataBuffer buffer;
 
+	public FlushingDataBuffer() {
+		this.buffer = new DefaultDataBufferFactory().allocateBuffer(0);
+	}
+
 	public FlushingDataBuffer(DataBuffer buffer) {
 		Assert.notNull(buffer);
 		this.buffer = buffer;
@@ -85,7 +89,7 @@ public class FlushingDataBuffer implements DataBuffer {
 
 	@Override
 	public DataBuffer write(byte[] source, int offset, int length) {
-		return this.write(source, offset, length);
+		return this.buffer.write(source, offset, length);
 	}
 
 	@Override
@@ -117,4 +121,5 @@ public class FlushingDataBuffer implements DataBuffer {
 	public OutputStream asOutputStream() {
 		return this.buffer.asOutputStream();
 	}
+
 }

--- a/src/main/java/org/springframework/core/io/buffer/FlushingDataBuffer.java
+++ b/src/main/java/org/springframework/core/io/buffer/FlushingDataBuffer.java
@@ -21,26 +21,25 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.function.IntPredicate;
 
-import org.springframework.util.Assert;
-
 /**
- * {@link DataBuffer} wrapper that indicates the file or the socket writing this buffer
- * should be flushed.
+ * Empty {@link DataBuffer} that indicates to the file or the socket writing it that
+ * previously buffered data should be flushed.
  *
  * @author Sebastien Deleuze
+ * @see FlushingDataBuffer#INSTANCE
  */
 public class FlushingDataBuffer implements DataBuffer {
 
+	/** Singleton instance of this class */
+	public static final FlushingDataBuffer INSTANCE = new FlushingDataBuffer();
+
 	private final DataBuffer buffer;
 
-	public FlushingDataBuffer() {
+
+	private FlushingDataBuffer() {
 		this.buffer = new DefaultDataBufferFactory().allocateBuffer(0);
 	}
 
-	public FlushingDataBuffer(DataBuffer buffer) {
-		Assert.notNull(buffer);
-		this.buffer = buffer;
-	}
 
 	@Override
 	public DataBufferFactory factory() {

--- a/src/main/java/org/springframework/http/ReactiveHttpOutputMessage.java
+++ b/src/main/java/org/springframework/http/ReactiveHttpOutputMessage.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.FlushingDataBuffer;
 
 /**
  * A "reactive" HTTP output message that accepts output as a {@link Publisher}.
@@ -46,6 +47,8 @@ public interface ReactiveHttpOutputMessage extends HttpMessage {
 	 * HTTP layer, and flush the data when the complete signal is received (data could be
 	 * flushed before depending on the configuration, the HTTP engine and the amount of
 	 * data sent).
+	 *
+	 * <p>Each {@link FlushingDataBuffer} element will trigger a flush.
 	 *
 	 * @param body the body content publisher
 	 * @return a publisher that indicates completion or error.

--- a/src/main/java/org/springframework/http/codec/SseEventEncoder.java
+++ b/src/main/java/org/springframework/http/codec/SseEventEncoder.java
@@ -115,7 +115,8 @@ public class SseEventEncoder extends AbstractEncoder<Object> {
 			return Flux.concat(
 					encodeString(sb.toString(), bufferFactory),
 					dataBuffer,
-					encodeString("\n", bufferFactory).map(b -> new FlushingDataBuffer(b))
+					encodeString("\n", bufferFactory),
+					Mono.just(FlushingDataBuffer.INSTANCE)
 			);
 		});
 

--- a/src/main/java/org/springframework/http/converter/reactive/SseHttpMessageConverter.java
+++ b/src/main/java/org/springframework/http/converter/reactive/SseHttpMessageConverter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.converter.reactive;
+
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.Encoder;
+import org.springframework.core.codec.support.JacksonJsonEncoder;
+import org.springframework.core.codec.support.SseEventEncoder;
+import org.springframework.core.codec.support.StringEncoder;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpOutputMessage;
+import org.springframework.web.reactive.sse.SseEvent;
+
+/**
+ * Implementation of {@link HttpMessageConverter} that can stream Server-Sent Events
+ * response.
+ *
+ * It allows to write {@code Flux<ServerSentEvent>}, which is Spring Web Reactive equivalent
+ * to Spring MVC {@code SseEmitter}.
+ *
+ * Sending {@code Flux<String>} or {@code Flux<Pojo>} is equivalent to sending
+ * {@code Flux<SseEvent>} with the {@code data} property set to the {@code String} or
+ * {@code Pojo} value.
+ *
+ * @author Sebastien Deleuze
+ * @see SseEvent
+ * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events W3C recommandation</a>
+ */
+public class SseHttpMessageConverter extends CodecHttpMessageConverter<Object> {
+
+	/**
+	 * Default constructor that creates a new instance configured with {@link StringEncoder}
+	 * and {@link JacksonJsonEncoder} encoders.
+	 */
+	public SseHttpMessageConverter() {
+		this(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
+	}
+
+	public SseHttpMessageConverter(Encoder<String> stringEncoder, List<Encoder<?>> dataEncoders) {
+		// 1 SseEvent element = 1 DataBuffer element so flush after each element
+		super(new SseEventEncoder(stringEncoder, dataEncoders), null);
+	}
+
+	@Override
+	public Mono<Void> write(Publisher<?> inputStream, ResolvableType type,
+			MediaType contentType, ReactiveHttpOutputMessage outputMessage) {
+
+		outputMessage.getHeaders().add("Content-Type", "text/event-stream");
+		// Keep the SSE connection open even for cold stream in order to avoid unexpected Browser reconnection
+		return super.write(Flux.from(inputStream).concatWith(Flux.never()), type, contentType, outputMessage);
+	}
+
+}

--- a/src/main/java/org/springframework/http/converter/reactive/SseHttpMessageConverter.java
+++ b/src/main/java/org/springframework/http/converter/reactive/SseHttpMessageConverter.java
@@ -26,9 +26,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.Encoder;
-import org.springframework.core.codec.support.JacksonJsonEncoder;
-import org.springframework.core.codec.support.SseEventEncoder;
-import org.springframework.core.codec.support.StringEncoder;
+import org.springframework.http.codec.SseEventEncoder;
 import org.springframework.http.MediaType;
 import org.springframework.http.ReactiveHttpOutputMessage;
 import org.springframework.web.reactive.sse.SseEvent;
@@ -51,16 +49,10 @@ import org.springframework.web.reactive.sse.SseEvent;
 public class SseHttpMessageConverter extends CodecHttpMessageConverter<Object> {
 
 	/**
-	 * Default constructor that creates a new instance configured with {@link StringEncoder}
-	 * and {@link JacksonJsonEncoder} encoders.
+	 * Constructor that creates a new instance configured with the specified data encoders.
 	 */
-	public SseHttpMessageConverter() {
-		this(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
-	}
-
-	public SseHttpMessageConverter(Encoder<String> stringEncoder, List<Encoder<?>> dataEncoders) {
-		// 1 SseEvent element = 1 DataBuffer element so flush after each element
-		super(new SseEventEncoder(stringEncoder, dataEncoders), null);
+	public SseHttpMessageConverter(List<Encoder<?>> dataEncoders) {
+		super(new SseEventEncoder(dataEncoders), null);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodySubscriber.java
+++ b/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodySubscriber.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server.reactive;
+
+import java.io.IOException;
+import java.nio.channels.Channel;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.servlet.WriteListener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.util.BackpressureUtils;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.FlushingDataBuffer;
+import org.springframework.core.io.buffer.support.DataBufferUtils;
+import org.springframework.util.Assert;
+
+/**
+ * Abstract base class for {@code Subscriber} implementations that bridge between
+ * event-listener APIs and Reactive Streams. Specifically, base class for the Servlet 3.1
+ * and Undertow support.
+ * @author Arjen Poutsma
+ * @see ServletServerHttpRequest
+ * @see UndertowHttpHandlerAdapter
+ */
+abstract class AbstractResponseBodySubscriber implements Subscriber<DataBuffer> {
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private final AtomicReference<State> state =
+			new AtomicReference<>(State.UNSUBSCRIBED);
+
+	private volatile DataBuffer currentBuffer;
+
+	private volatile boolean subscriptionCompleted;
+
+	private Subscription subscription;
+
+	@Override
+	public final void onSubscribe(Subscription subscription) {
+		if (logger.isTraceEnabled()) {
+			logger.trace(this.state + " onSubscribe: " + subscription);
+		}
+		this.state.get().onSubscribe(this, subscription);
+	}
+
+	@Override
+	public final void onNext(DataBuffer dataBuffer) {
+		if (logger.isTraceEnabled()) {
+			logger.trace(this.state + " onNext: " + dataBuffer);
+		}
+		this.state.get().onNext(this, dataBuffer);
+	}
+
+	@Override
+	public final void onError(Throwable t) {
+		if (logger.isErrorEnabled()) {
+			logger.error(this.state + " onError: " + t, t);
+		}
+		this.state.get().onError(this, t);
+	}
+
+	@Override
+	public final void onComplete() {
+		if (logger.isTraceEnabled()) {
+			logger.trace(this.state + " onComplete");
+		}
+		this.state.get().onComplete(this);
+	}
+
+	/**
+	 * Called via a listener interface to indicate that writing is possible.
+	 * @see WriteListener#onWritePossible()
+	 * @see org.xnio.ChannelListener#handleEvent(Channel)
+	 */
+	protected final void onWritePossible() {
+		this.state.get().onWritePossible(this);
+	}
+
+	/**
+	 * Called when a {@link DataBuffer} is received via {@link Subscriber#onNext(Object)}
+	 * @param dataBuffer the buffer that was received.
+	 */
+	protected void receiveBuffer(DataBuffer dataBuffer) {
+		Assert.state(this.currentBuffer == null);
+		this.currentBuffer = dataBuffer;
+	}
+
+	/**
+	 * Called when the current buffer should be
+	 * {@linkplain DataBufferUtils#release(DataBuffer) released}.
+	 */
+	protected void releaseBuffer() {
+		if (logger.isTraceEnabled()) {
+			logger.trace("releaseBuffer: " + this.currentBuffer);
+		}
+		DataBufferUtils.release(this.currentBuffer);
+		this.currentBuffer = null;
+	}
+
+	/**
+	 * Writes the given data buffer to the output, indicating if the entire buffer was
+	 * written.
+	 * @param dataBuffer the data buffer to write
+	 * @return {@code true} if {@code dataBuffer} was fully written and a new buffer
+	 * can be requested; {@code false} otherwise
+	 */
+	protected abstract boolean write(DataBuffer dataBuffer) throws IOException;
+
+	/**
+	 * Writes the given exception to the output.
+	 */
+	protected abstract void writeError(Throwable t);
+
+	/**
+	 * Flushes the output.
+	 */
+	protected abstract void flush() throws IOException;
+
+	/**
+	 * Closes the output.
+	 */
+	protected abstract void close();
+
+	private void changeState(State oldState, State newState) {
+		this.state.compareAndSet(oldState, newState);
+	}
+
+	/**
+	 * Represents a state for the {@link Subscriber} to be in. The following figure
+	 * indicate the four different states that exist, and the relationships between them.
+	 *
+	 * <pre>
+	 *       UNSUBSCRIBED
+	 *        |
+	 *        v
+	 * REQUESTED <---> RECEIVED
+	 *         |       |
+	 *         v       v
+	 *         COMPLETED
+	 * </pre>
+	 * Refer to the individual states for more information.
+	 */
+	private enum State {
+
+		/**
+		 * The initial unsubscribed state. Will respond to {@code onSubscribe} by
+		 * requesting 1 buffer from the subscription, and change state to {@link
+		 * #REQUESTED}.
+		 */
+		UNSUBSCRIBED {
+			@Override
+			void onSubscribe(AbstractResponseBodySubscriber subscriber,
+					Subscription subscription) {
+				if (BackpressureUtils.validate(subscriber.subscription, subscription)) {
+					subscriber.subscription = subscription;
+					subscriber.changeState(this, REQUESTED);
+					subscription.request(1);
+				}
+			}
+		},
+		/**
+		 * State that gets entered after a buffer has been
+		 * {@linkplain Subscription#request(long) requested}. Responds to {@code onNext}
+		 * by changing state to {@link #RECEIVED}, and responds to {@code onComplete} by
+		 * changing state to {@link #COMPLETED}.
+		 */
+		REQUESTED {
+			@Override
+			void onNext(AbstractResponseBodySubscriber subscriber,
+					DataBuffer dataBuffer) {
+				subscriber.changeState(this, RECEIVED);
+				subscriber.receiveBuffer(dataBuffer);
+			}
+
+			@Override
+			void onComplete(AbstractResponseBodySubscriber subscriber) {
+				subscriber.subscriptionCompleted = true;
+				subscriber.changeState(this, COMPLETED);
+				subscriber.close();
+			}
+		},
+		/**
+		 * State that gets entered after a buffer has been
+		 * {@linkplain Subscriber#onNext(Object) received}. Responds to
+		 * {@code onWritePossible} by writing the current buffer, and if it can be
+		 * written completely, changes state to either {@link #REQUESTED} if the
+		 * subscription has not been completed; or {@link #COMPLETED} if it has.
+		 */
+		RECEIVED {
+			@Override
+			void onWritePossible(AbstractResponseBodySubscriber subscriber) {
+				DataBuffer dataBuffer = subscriber.currentBuffer;
+				try {
+					boolean writeCompleted = subscriber.write(dataBuffer);
+					if (writeCompleted) {
+						if (dataBuffer instanceof FlushingDataBuffer) {
+							subscriber.flush();
+						}
+						subscriber.releaseBuffer();
+						boolean subscriptionCompleted = subscriber.subscriptionCompleted;
+						if (!subscriptionCompleted) {
+							subscriber.changeState(this, REQUESTED);
+							subscriber.subscription.request(1);
+						}
+						else {
+							subscriber.changeState(this, COMPLETED);
+							subscriber.close();
+						}
+					}
+				}
+				catch (IOException ex) {
+					subscriber.onError(ex);
+				}
+			}
+
+			@Override
+			void onComplete(AbstractResponseBodySubscriber subscriber) {
+				subscriber.subscriptionCompleted = true;
+			}
+		},
+		/**
+		 * The terminal completed state. Does not respond to any events.
+		 */
+		COMPLETED {
+			@Override
+			void onNext(AbstractResponseBodySubscriber subscriber,
+					DataBuffer dataBuffer) {
+				// ignore
+			}
+
+			@Override
+			void onError(AbstractResponseBodySubscriber subscriber, Throwable t) {
+				// ignore
+			}
+
+			@Override
+			void onComplete(AbstractResponseBodySubscriber subscriber) {
+				// ignore
+			}
+		};
+
+		void onSubscribe(AbstractResponseBodySubscriber subscriber, Subscription s) {
+			throw new IllegalStateException(toString());
+		}
+
+		void onNext(AbstractResponseBodySubscriber subscriber, DataBuffer dataBuffer) {
+			throw new IllegalStateException(toString());
+		}
+
+		void onError(AbstractResponseBodySubscriber subscriber, Throwable t) {
+			subscriber.changeState(this, COMPLETED);
+			subscriber.writeError(t);
+			subscriber.close();
+		}
+
+		void onComplete(AbstractResponseBodySubscriber subscriber) {
+			throw new IllegalStateException(toString());
+		}
+
+		void onWritePossible(AbstractResponseBodySubscriber subscriber) {
+			// ignore
+		}
+
+	}
+
+}

--- a/src/main/java/org/springframework/http/server/reactive/ServletHttpHandlerAdapter.java
+++ b/src/main/java/org/springframework/http/server/reactive/ServletHttpHandlerAdapter.java
@@ -247,7 +247,10 @@ public class ServletHttpHandlerAdapter extends HttpServlet {
 
 		private volatile boolean completed = false;
 
+		private volatile boolean flushOnNext = false;
+
 		private Subscription subscription;
+
 
 		public ResponseBodySubscriber(ServletAsyncContextSynchronizer synchronizer,
 				int bufferSize) {
@@ -321,6 +324,12 @@ public class ServletHttpHandlerAdapter extends HttpServlet {
 				ServletOutputStream output = synchronizer.getResponse().getOutputStream();
 
 				boolean ready = output.isReady();
+
+				if (flushOnNext) {
+					flush(output);
+					ready = output.isReady();
+				}
+
 				logger.trace("ready: " + ready + " buffer: " + dataBuffer);
 
 				if (ready) {
@@ -370,9 +379,12 @@ public class ServletHttpHandlerAdapter extends HttpServlet {
 					logger.trace("Flushing");
 					try {
 						output.flush();
+						flushOnNext = false;
 					}
 					catch (IOException ignored) {
 					}
+				} else {
+					flushOnNext = true;
 				}
 			}
 

--- a/src/main/java/org/springframework/web/reactive/sse/SseEvent.java
+++ b/src/main/java/org/springframework/web/reactive/sse/SseEvent.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.sse;
+
+import org.springframework.http.converter.reactive.SseHttpMessageConverter;
+import org.springframework.util.MimeType;
+
+/**
+ * Represent a Server-Sent Event.
+ *
+ * <p>{@code Flux<SseEvent>} is Spring Web Reactive equivalent to Spring MVC
+ * {@code SseEmitter} type. It allows to send Server-Sent Events in a reactive way.
+ *
+ * @author Sebastien Deleuze
+ * @see SseHttpMessageConverter
+ * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events W3C recommandation</a>
+ */
+public class SseEvent {
+
+	private String id;
+
+	private String name;
+
+	private Object data;
+
+	private MimeType mimeType;
+
+	private Long reconnectTime;
+
+	private String comment;
+
+	/**
+	 * Create an empty instance.
+	 */
+	public SseEvent() {
+	}
+
+	/**
+	 * Create an instance with the provided {@code data}.
+	 */
+	public SseEvent(Object data) {
+		this.data = data;
+	}
+
+	/**
+	 * Create an instance with the provided {@code data} and {@code mediaType}.
+	 */
+	public SseEvent(Object data, MimeType mimeType) {
+		this.data = data;
+		this.mimeType = mimeType;
+	}
+
+	/**
+	 * Set the {@code id} SSE field
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	/**
+	 * @see #setId(String)
+	 */
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * Set the {@code event} SSE field
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @see #setName(String)
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Set {@code data} SSE field. If a multiline {@code String} is provided, it will be
+	 * turned into multiple {@code data} field lines by  as
+	 * defined in Server-Sent Events W3C recommandation.
+	 *
+	 * If no {@code mediaType} is defined, default {@link SseHttpMessageConverter} will:
+	 *  - Turn single line {@code String} to a single {@code data} field
+	 *  - Turn multiline line {@code String} to multiple {@code data} fields
+	 *  - Serialize other {@code Object} as JSON
+	 *
+	 * @see #setMimeType(MimeType)
+	 */
+	public void setData(Object data) {
+		this.data = data;
+	}
+
+	/**
+	 * @see #setData(Object)
+	 */
+	public Object getData() {
+		return data;
+	}
+
+	/**
+	 * Set the {@link MimeType} used to serialize the {@code data}.
+	 * {@link SseHttpMessageConverter} should be configured with the relevant encoder to be
+	 * able to serialize it.
+	 */
+	public void setMimeType(MimeType mimeType) {
+		this.mimeType = mimeType;
+	}
+
+	/**
+	 * @see #setMimeType(MimeType)
+	 */
+	public MimeType getMimeType() {
+		return mimeType;
+	}
+
+	/**
+	 * Set the {@code retry} SSE field
+	 */
+	public void setReconnectTime(Long reconnectTime) {
+		this.reconnectTime = reconnectTime;
+	}
+
+	/**
+	 * @see #setReconnectTime(Long)
+	 */
+	public Long getReconnectTime() {
+		return reconnectTime;
+	}
+
+	/**
+	 * Set SSE comment. If a multiline comment is provided, it will be turned into multiple
+	 * SSE comment lines by {@link SseHttpMessageConverter} as defined in Server-Sent Events W3C
+	 * recommandation.
+	 */
+	public void setComment(String comment) {
+		this.comment = comment;
+	}
+
+	/**
+	 * @see #setComment(String)
+	 */
+	public String getComment() {
+		return comment;
+	}
+
+}

--- a/src/test/java/org/springframework/core/codec/support/SseEventEncoderTests.java
+++ b/src/test/java/org/springframework/core/codec/support/SseEventEncoderTests.java
@@ -18,6 +18,7 @@ package org.springframework.core.codec.support;
 
 import java.util.Arrays;
 
+import static org.junit.Assert.*;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -26,13 +27,10 @@ import reactor.core.test.TestSubscriber;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
 import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.FlushingDataBuffer;
 import org.springframework.http.codec.SseEventEncoder;
 import org.springframework.util.MimeType;
 import org.springframework.web.reactive.sse.SseEvent;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 
 /**
  * @author Sebastien Deleuze
@@ -77,7 +75,8 @@ public class SseEventEncoderTests extends AbstractDataBufferAllocatingTestCase {
 								"event:foo\n" +
 								"retry:123\n" +
 								":bla\n:bla bla\n:bla bla bla\n"),
-						stringConsumer("\n")
+						stringConsumer("\n"),
+						b -> assertEquals(FlushingDataBuffer.class, b.getClass())
 				);
 	}
 
@@ -93,8 +92,10 @@ public class SseEventEncoderTests extends AbstractDataBufferAllocatingTestCase {
 				.assertValuesWith(
 						stringConsumer("data:foo\n"),
 						stringConsumer("\n"),
+						b -> assertEquals(FlushingDataBuffer.class, b.getClass()),
 						stringConsumer("data:bar\n"),
-						stringConsumer("\n")
+						stringConsumer("\n"),
+						b -> assertEquals(FlushingDataBuffer.class, b.getClass())
 				);
 	}
 
@@ -110,11 +111,12 @@ public class SseEventEncoderTests extends AbstractDataBufferAllocatingTestCase {
 				.assertValuesWith(
 						stringConsumer("data:foo\ndata:bar\n"),
 						stringConsumer("\n"),
+						b -> assertEquals(FlushingDataBuffer.class, b.getClass()),
 						stringConsumer("data:foo\ndata:baz\n"),
-						stringConsumer("\n")
+						stringConsumer("\n"),
+						b -> assertEquals(FlushingDataBuffer.class, b.getClass())
 				);
 	}
-
 
 	@Test
 	public void encodePojo() {
@@ -130,10 +132,12 @@ public class SseEventEncoderTests extends AbstractDataBufferAllocatingTestCase {
 						stringConsumer("{\"foo\":\"foofoo\",\"bar\":\"barbar\"}"),
 						stringConsumer("\n"),
 						stringConsumer("\n"),
+						b -> assertEquals(FlushingDataBuffer.class, b.getClass()),
 						stringConsumer("data:"),
 						stringConsumer("{\"foo\":\"foofoofoo\",\"bar\":\"barbarbar\"}"),
 						stringConsumer("\n"),
-						stringConsumer("\n")
+						stringConsumer("\n"),
+						b -> assertEquals(FlushingDataBuffer.class, b.getClass())
 				);
 	}
 

--- a/src/test/java/org/springframework/core/codec/support/SseEventEncoderTests.java
+++ b/src/test/java/org/springframework/core/codec/support/SseEventEncoderTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.codec.support;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.test.TestSubscriber;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.util.MimeType;
+import org.springframework.web.reactive.sse.SseEvent;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class SseEventEncoderTests extends AbstractDataBufferAllocatingTestCase {
+
+	@Test
+	public void nullMimeType() {
+		SseEventEncoder encoder = new SseEventEncoder(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
+		assertTrue(encoder.canEncode(ResolvableType.forClass(Object.class), null));
+	}
+
+	@Test
+	public void unsupportedMimeType() {
+		SseEventEncoder encoder = new SseEventEncoder(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
+		assertFalse(encoder.canEncode(ResolvableType.forClass(Object.class), new MimeType("foo", "bar")));
+	}
+
+	@Test
+	public void supportedMimeType() {
+		SseEventEncoder encoder = new SseEventEncoder(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
+		assertTrue(encoder.canEncode(ResolvableType.forClass(Object.class), new MimeType("text", "event-stream")));
+	}
+
+	@Test
+	public void encodeServerSentEvent() {
+		SseEventEncoder encoder = new SseEventEncoder(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
+		SseEvent event = new SseEvent();
+		event.setId("c42");
+		event.setName("foo");
+		event.setComment("bla\nbla bla\nbla bla bla");
+		event.setReconnectTime(123L);
+		Mono<SseEvent> source = Mono.just(event);
+		Flux<DataBuffer> output = encoder.encode(source, this.dataBufferFactory,
+						ResolvableType.forClass(SseEvent.class), new MimeType("text", "event-stream"));
+		TestSubscriber
+				.subscribe(output)
+				.assertNoError()
+				.assertValuesWith(
+						stringConsumer(
+								"id:c42\n" +
+								"event:foo\n" +
+								"retry:123\n" +
+								":bla\n:bla bla\n:bla bla bla\n"),
+						stringConsumer("\n")
+				);
+	}
+
+	@Test
+	public void encodeString() {
+		SseEventEncoder encoder = new SseEventEncoder(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
+		Flux<String> source = Flux.just("foo", "bar");
+		Flux<DataBuffer> output = encoder.encode(source, this.dataBufferFactory,
+				ResolvableType.forClass(String.class), new MimeType("text", "event-stream"));
+		TestSubscriber
+				.subscribe(output)
+				.assertNoError()
+				.assertValuesWith(
+						stringConsumer("data:foo\n"),
+						stringConsumer("\n"),
+						stringConsumer("data:bar\n"),
+						stringConsumer("\n")
+				);
+	}
+
+	@Test
+	public void encodeMultilineString() {
+		SseEventEncoder encoder = new SseEventEncoder(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
+		Flux<String> source = Flux.just("foo\nbar", "foo\nbaz");
+		Flux<DataBuffer> output = encoder.encode(source, this.dataBufferFactory,
+				ResolvableType.forClass(String.class), new MimeType("text", "event-stream"));
+		TestSubscriber
+				.subscribe(output)
+				.assertNoError()
+				.assertValuesWith(
+						stringConsumer("data:foo\ndata:bar\n"),
+						stringConsumer("\n"),
+						stringConsumer("data:foo\ndata:baz\n"),
+						stringConsumer("\n")
+				);
+	}
+
+
+	@Test
+	public void encodePojo() {
+		SseEventEncoder encoder = new SseEventEncoder(new StringEncoder(), Arrays.asList(new JacksonJsonEncoder()));
+		Flux<Pojo> source = Flux.just(new Pojo("foofoo", "barbar"), new Pojo("foofoofoo", "barbarbar"));
+		Flux<DataBuffer> output = encoder.encode(source, this.dataBufferFactory,
+						ResolvableType.forClass(Pojo.class), new MimeType("text", "event-stream"));
+		TestSubscriber
+				.subscribe(output)
+				.assertNoError()
+				.assertValuesWith(
+						stringConsumer("data:{\"foo\":\"foofoo\",\"bar\":\"barbar\"}\n"),
+						stringConsumer("\n"),
+						stringConsumer("data:{\"foo\":\"foofoofoo\",\"bar\":\"barbarbar\"}\n"),
+						stringConsumer("\n")
+				);
+	}
+
+}

--- a/src/test/java/org/springframework/http/server/reactive/FlushingIntegrationTests.java
+++ b/src/test/java/org/springframework/http/server/reactive/FlushingIntegrationTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server.reactive;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.springframework.web.client.reactive.HttpRequestBuilders.get;
+import static org.springframework.web.client.reactive.WebResponseExtractors.bodyStream;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.test.TestSubscriber;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.FlushingDataBuffer;
+import org.springframework.http.client.reactive.ReactorHttpClientRequestFactory;
+import org.springframework.web.client.reactive.WebClient;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class FlushingIntegrationTests extends AbstractHttpHandlerIntegrationTests {
+
+	private WebClient webClient;
+
+	@Before
+	public void setup() throws Exception {
+		super.setup();
+		this.webClient = new WebClient(new ReactorHttpClientRequestFactory());
+	}
+
+	@Test
+	public void testFlushing() throws Exception {
+		Mono<String> result = this.webClient
+				.perform(get("http://localhost:" + port))
+				.extract(bodyStream(String.class))
+				.take(2)
+				.reduce((s1, s2) -> s1 + s2);
+
+		TestSubscriber
+				.subscribe(result)
+				.await()
+				.assertValues("data0data1");
+	}
+
+
+	@Override
+	protected HttpHandler createHttpHandler() {
+		return new FlushingHandler();
+	}
+
+	private static class FlushingHandler implements HttpHandler {
+
+		@Override
+		public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+			Flux<DataBuffer> responseBody = Flux
+					.interval(50)
+					.take(2)
+					.concatWith(Flux.never())
+					.map(l -> {
+						byte[] data = ("data" + l).getBytes();
+						DataBuffer buffer = response.bufferFactory().allocateBuffer(data.length);
+						buffer.write(data);
+						return new FlushingDataBuffer(buffer);
+					});
+			return response.writeWith(responseBody);
+		}
+	}
+}

--- a/src/test/java/org/springframework/http/server/reactive/FlushingIntegrationTests.java
+++ b/src/test/java/org/springframework/http/server/reactive/FlushingIntegrationTests.java
@@ -62,6 +62,8 @@ public class FlushingIntegrationTests extends AbstractHttpHandlerIntegrationTest
 		return new FlushingHandler();
 	}
 
+	// Handler that never completes designed to test if flushing is perform correctly when
+	// a FlushingDataBuffer is written
 	private static class FlushingHandler implements HttpHandler {
 
 		@Override

--- a/src/test/java/org/springframework/http/server/reactive/FlushingIntegrationTests.java
+++ b/src/test/java/org/springframework/http/server/reactive/FlushingIntegrationTests.java
@@ -70,14 +70,15 @@ public class FlushingIntegrationTests extends AbstractHttpHandlerIntegrationTest
 		public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
 			Flux<DataBuffer> responseBody = Flux
 					.interval(50)
-					.take(2)
-					.concatWith(Flux.never())
 					.map(l -> {
 						byte[] data = ("data" + l).getBytes();
 						DataBuffer buffer = response.bufferFactory().allocateBuffer(data.length);
 						buffer.write(data);
-						return new FlushingDataBuffer(buffer);
-					});
+						return buffer;
+					})
+					.take(2)
+					.concatWith(Mono.just(FlushingDataBuffer.INSTANCE))
+					.concatWith(Flux.never());
 			return response.writeWith(responseBody);
 		}
 	}

--- a/src/test/java/org/springframework/web/reactive/result/method/annotation/SseIntegrationTests.java
+++ b/src/test/java/org/springframework/web/reactive/result/method/annotation/SseIntegrationTests.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import static org.springframework.web.client.reactive.HttpRequestBuilders.get;
+import static org.springframework.web.client.reactive.WebResponseExtractors.bodyStream;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.test.TestSubscriber;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.codec.support.ByteBufferDecoder;
+import org.springframework.core.codec.support.JacksonJsonDecoder;
+import org.springframework.core.codec.support.JsonObjectDecoder;
+import org.springframework.core.codec.support.StringDecoder;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.core.convert.support.ReactiveStreamsToCompletableFutureConverter;
+import org.springframework.core.convert.support.ReactiveStreamsToRxJava1Converter;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorHttpClientRequestFactory;
+import org.springframework.http.converter.reactive.HttpMessageConverter;
+import org.springframework.http.converter.reactive.SseHttpMessageConverter;
+import org.springframework.http.server.reactive.AbstractHttpHandlerIntegrationTests;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.boot.JettyHttpServer;
+import org.springframework.http.server.reactive.boot.ReactorHttpServer;
+import org.springframework.http.server.reactive.boot.RxNettyHttpServer;
+import org.springframework.http.server.reactive.boot.TomcatHttpServer;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.reactive.WebClient;
+import org.springframework.web.reactive.DispatcherHandler;
+import org.springframework.web.reactive.result.SimpleResultHandler;
+import org.springframework.web.reactive.sse.SseEvent;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class SseIntegrationTests extends AbstractHttpHandlerIntegrationTests {
+
+	// TODO Fix Undertow support and remove this method
+	@Parameterized.Parameters(name = "server [{0}]")
+	public static Object[][] arguments() {
+		return new Object[][] {
+				{new JettyHttpServer()},
+				{new RxNettyHttpServer()},
+				{new ReactorHttpServer()},
+				{new TomcatHttpServer()},
+		};
+	}
+
+	private AnnotationConfigApplicationContext wac;
+
+	private WebClient webClient;
+
+	@Before
+	public void setup() throws Exception {
+		super.setup();
+		this.webClient = new WebClient(new ReactorHttpClientRequestFactory());
+		this.webClient.setMessageDecoders(Arrays.asList(
+				new ByteBufferDecoder(),
+				new StringDecoder(false),
+				new JacksonJsonDecoder(new JsonObjectDecoder())));
+	}
+
+	@Override
+	protected HttpHandler createHttpHandler() {
+		this.wac = new AnnotationConfigApplicationContext();
+		this.wac.register(TestConfiguration.class);
+		this.wac.refresh();
+
+		DispatcherHandler webHandler = new DispatcherHandler();
+		webHandler.setApplicationContext(this.wac);
+
+		return WebHttpHandlerBuilder.webHandler(webHandler).build();
+	}
+
+	@Test
+	public void sseAsString() throws Exception {
+		Mono<String> result = this.webClient
+				.perform(get("http://localhost:" + port + "/sse/string")
+				.accept(new MediaType("text", "event-stream")))
+				.extract(bodyStream(String.class))
+				.take(Duration.ofMillis(500))
+				.reduce((s1, s2) -> s1 + s2);
+
+		TestSubscriber
+				.subscribe(result)
+				.await()
+				.assertValues("data:foo 0\n\ndata:foo 1\n\n");
+	}
+
+	@Test
+	public void sseAsPojo() throws Exception {
+		Mono<String> result = this.webClient
+				.perform(get("http://localhost:" + port + "/sse/person")
+				.accept(new MediaType("text", "event-stream")))
+				.extract(bodyStream(String.class))
+				.take(Duration.ofMillis(500))
+				.reduce((s1, s2) -> s1 + s2);
+
+		TestSubscriber
+				.subscribe(result)
+				.await()
+				.assertValues("data:{\"name\":\"foo 0\"}\n\ndata:{\"name\":\"foo 1\"}\n\n");
+	}
+
+	@Test
+	public void sseAsEvent() throws Exception {
+		Mono<String> result = this.webClient
+				.perform(get("http://localhost:" + port + "/sse/event")
+				.accept(new MediaType("text", "event-stream")))
+				.extract(bodyStream(String.class))
+				.take(Duration.ofMillis(500))
+				.reduce((s1, s2) -> s1 + s2);
+
+		TestSubscriber
+				.subscribe(result)
+				.await()
+				.assertValues("id:0\n:bar\ndata:foo\n\nid:1\n:bar\ndata:foo\n\n");
+	}
+
+	@RestController
+	@SuppressWarnings("unused")
+	static class SseController {
+
+		@RequestMapping("/sse/string")
+		Flux<String> string() {
+			return Flux.interval(Duration.ofMillis(100)).map(l -> "foo " + l).take(2);
+		}
+
+		@RequestMapping("/sse/person")
+		Flux<Person> person() {
+			return Flux.interval(Duration.ofMillis(100)).map(l -> new Person("foo " + l)).take(2);
+		}
+
+		@RequestMapping("/sse/event")
+		Flux<SseEvent> sse() {
+			return Flux.interval(Duration.ofMillis(100)).map(l -> {
+				SseEvent event = new SseEvent();
+				event.setId(Long.toString(l));
+				event.setData("foo");
+				event.setComment("bar");
+				return event;
+			}).take(2);
+		}
+
+	}
+
+	@Configuration
+	@SuppressWarnings("unused")
+	static class TestConfiguration {
+
+		private DataBufferFactory dataBufferFactory = new DefaultDataBufferFactory();
+
+		@Bean
+		public SseController sseController() {
+			return new SseController();
+		}
+
+		@Bean
+		public RequestMappingHandlerMapping handlerMapping() {
+			return new RequestMappingHandlerMapping();
+		}
+
+		@Bean
+		public RequestMappingHandlerAdapter handlerAdapter() {
+			RequestMappingHandlerAdapter handlerAdapter = new RequestMappingHandlerAdapter();
+			handlerAdapter.setConversionService(conversionService());
+			return handlerAdapter;
+		}
+
+		@Bean
+		public ConversionService conversionService() {
+			GenericConversionService service = new GenericConversionService();
+			service.addConverter(new ReactiveStreamsToCompletableFutureConverter());
+			service.addConverter(new ReactiveStreamsToRxJava1Converter());
+			return service;
+		}
+
+		@Bean
+		public ResponseBodyResultHandler responseBodyResultHandler() {
+			List<HttpMessageConverter<?>> converters = Arrays.asList(new SseHttpMessageConverter());
+			return new ResponseBodyResultHandler(converters, conversionService());
+		}
+
+		@Bean
+		public SimpleResultHandler simpleHandlerResultHandler() {
+			return new SimpleResultHandler(conversionService());
+		}
+
+	}
+
+	private static class Person {
+
+		private String name;
+
+		@SuppressWarnings("unused")
+		public Person() {
+		}
+
+		public Person(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Person person = (Person) o;
+			return !(this.name != null ? !this.name.equals(person.name) : person.name != null);
+		}
+
+		@Override
+		public int hashCode() {
+			return this.name != null ? this.name.hashCode() : 0;
+		}
+
+		@Override
+		public String toString() {
+			return "Person{" +
+					"name='" + name + '\'' +
+					'}';
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/web/reactive/result/method/annotation/SseIntegrationTests.java
+++ b/src/test/java/org/springframework/web/reactive/result/method/annotation/SseIntegrationTests.java
@@ -22,9 +22,6 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runners.Parameterized;
-import static org.springframework.web.client.reactive.HttpRequestBuilders.get;
-import static org.springframework.web.client.reactive.WebResponseExtractors.bodyStream;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.test.TestSubscriber;
@@ -43,10 +40,6 @@ import org.springframework.http.converter.reactive.HttpMessageConverter;
 import org.springframework.http.converter.reactive.SseHttpMessageConverter;
 import org.springframework.http.server.reactive.AbstractHttpHandlerIntegrationTests;
 import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.http.server.reactive.boot.JettyHttpServer;
-import org.springframework.http.server.reactive.boot.ReactorHttpServer;
-import org.springframework.http.server.reactive.boot.RxNettyHttpServer;
-import org.springframework.http.server.reactive.boot.TomcatHttpServer;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.reactive.WebClient;
@@ -55,21 +48,13 @@ import org.springframework.web.reactive.config.WebReactiveConfiguration;
 import org.springframework.web.reactive.sse.SseEvent;
 import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
 
+import static org.springframework.web.client.reactive.HttpRequestBuilders.get;
+import static org.springframework.web.client.reactive.WebResponseExtractors.bodyStream;
+
 /**
  * @author Sebastien Deleuze
  */
 public class SseIntegrationTests extends AbstractHttpHandlerIntegrationTests {
-
-	// TODO Fix Undertow support and remove this method
-	@Parameterized.Parameters(name = "server [{0}]")
-	public static Object[][] arguments() {
-		return new Object[][] {
-				{new JettyHttpServer()},
-				{new RxNettyHttpServer()},
-				{new ReactorHttpServer()},
-				{new TomcatHttpServer()},
-		};
-	}
 
 	private AnnotationConfigApplicationContext wac;
 


### PR DESCRIPTION
This pull request contains 2 distinct commit:
 - This first add flushing supports to `ReactiveHttpOutputMessage`
 - The second is the SSE support

`Flux<SseEvent>` is Spring Web Reactive equivalent to Spring MVC `SseEmitter` type. It allows to send Server-Sent Events in a reactive way. Sending `Flux<String>` or `Flux<Pojo>` is equivalent to sending `Flux<SseEvent>` with the data property set to the String or Pojo value. For example:

```java
@RestController
public class SseController {

	@RequestMapping("/sse/string")
	Flux<String> string() {
		return Flux.interval(Duration.ofSeconds(1)).map(l -> "foo " + l);
	}

	@RequestMapping("/sse/person")
	Flux<Person> person() {
		return Flux.interval(Duration.ofSeconds(1)).map(l -> new Person(Long.toString(l), "foo", "bar"));
	}

	@RequestMapping("/sse-raw")
	Flux<SseEvent> sse() {
		return Flux.interval(Duration.ofSeconds(1)).map(l -> {
			SseEvent event = new SseEvent();
			event.setId(Long.toString(l));
			event.setData("foo\nbar");
			event.setComment("bar\nbaz");
			return event;
		});
	}
}
```