### PR TITLE
Move server testing infrastructure to test sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ target
 /.idea/
 bin
 .gradle
-tomcat*
+/tomcat.*/
 build

--- a/src/test/java/org/springframework/http/server/reactive/AbstractHttpHandlerIntegrationTests.java
+++ b/src/test/java/org/springframework/http/server/reactive/AbstractHttpHandlerIntegrationTests.java
@@ -23,12 +23,12 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.springframework.http.server.reactive.boot.HttpServer;
-import org.springframework.http.server.reactive.boot.JettyHttpServer;
-import org.springframework.http.server.reactive.boot.ReactorHttpServer;
-import org.springframework.http.server.reactive.boot.RxNettyHttpServer;
-import org.springframework.http.server.reactive.boot.TomcatHttpServer;
-import org.springframework.http.server.reactive.boot.UndertowHttpServer;
+import org.springframework.http.server.reactive.bootstrap.HttpServer;
+import org.springframework.http.server.reactive.bootstrap.JettyHttpServer;
+import org.springframework.http.server.reactive.bootstrap.ReactorHttpServer;
+import org.springframework.http.server.reactive.bootstrap.RxNettyHttpServer;
+import org.springframework.http.server.reactive.bootstrap.TomcatHttpServer;
+import org.springframework.http.server.reactive.bootstrap.UndertowHttpServer;
 import org.springframework.util.SocketUtils;
 
 

--- a/src/test/java/org/springframework/http/server/reactive/ErrorHandlerIntegrationTests.java
+++ b/src/test/java/org/springframework/http/server/reactive/ErrorHandlerIntegrationTests.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.server.reactive.boot.ReactorHttpServer;
+import org.springframework.http.server.reactive.bootstrap.ReactorHttpServer;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 

--- a/src/test/java/org/springframework/http/server/reactive/ZeroCopyIntegrationTests.java
+++ b/src/test/java/org/springframework/http/server/reactive/ZeroCopyIntegrationTests.java
@@ -28,8 +28,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ZeroCopyHttpOutputMessage;
-import org.springframework.http.server.reactive.boot.ReactorHttpServer;
-import org.springframework.http.server.reactive.boot.UndertowHttpServer;
+import org.springframework.http.server.reactive.bootstrap.ReactorHttpServer;
+import org.springframework.http.server.reactive.bootstrap.UndertowHttpServer;
 import org.springframework.web.client.RestTemplate;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/springframework/http/server/reactive/bootstrap/HttpServer.java
+++ b/src/test/java/org/springframework/http/server/reactive/bootstrap/HttpServer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.http.server.reactive.boot;
+package org.springframework.http.server.reactive.bootstrap;
 
 
 import org.springframework.beans.factory.InitializingBean;

--- a/src/test/java/org/springframework/http/server/reactive/bootstrap/HttpServerSupport.java
+++ b/src/test/java/org/springframework/http/server/reactive/bootstrap/HttpServerSupport.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.http.server.reactive.boot;
+package org.springframework.http.server.reactive.bootstrap;
 
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.util.SocketUtils;

--- a/src/test/java/org/springframework/http/server/reactive/bootstrap/JettyHttpServer.java
+++ b/src/test/java/org/springframework/http/server/reactive/bootstrap/JettyHttpServer.java
@@ -14,37 +14,25 @@
  * limitations under the License.
  */
 
-package org.springframework.http.server.reactive.boot;
+package org.springframework.http.server.reactive.bootstrap;
 
-import java.io.File;
-
-import org.apache.catalina.Context;
-import org.apache.catalina.LifecycleException;
-import org.apache.catalina.startup.Tomcat;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.http.server.reactive.ServletHttpHandlerAdapter;
 import org.springframework.util.Assert;
 
-
 /**
  * @author Rossen Stoyanchev
  */
-public class TomcatHttpServer extends HttpServerSupport implements InitializingBean, HttpServer {
+public class JettyHttpServer extends HttpServerSupport implements InitializingBean, HttpServer {
 
-	private Tomcat tomcatServer;
+	private Server jettyServer;
 
 	private boolean running;
-
-	private String baseDir;
-
-
-	public TomcatHttpServer() {
-	}
-
-	public TomcatHttpServer(String baseDir) {
-		this.baseDir = baseDir;
-	}
 
 
 	@Override
@@ -55,32 +43,30 @@ public class TomcatHttpServer extends HttpServerSupport implements InitializingB
 	@Override
 	public void afterPropertiesSet() throws Exception {
 
-		this.tomcatServer = new Tomcat();
-		if (this.baseDir != null) {
-			this.tomcatServer.setBaseDir(baseDir);
-		}
-		this.tomcatServer.setHostname(getHost());
-		this.tomcatServer.setPort(getPort());
+		this.jettyServer = new Server();
 
 		Assert.notNull(getHttpHandler());
 		ServletHttpHandlerAdapter servlet = new ServletHttpHandlerAdapter();
 		servlet.setHandler(getHttpHandler());
+		ServletHolder servletHolder = new ServletHolder(servlet);
 
-		File base = new File(System.getProperty("java.io.tmpdir"));
-		Context rootContext = tomcatServer.addContext("", base.getAbsolutePath());
-		Tomcat.addServlet(rootContext, "httpHandlerServlet", servlet);
-		rootContext.addServletMapping("/", "httpHandlerServlet");
+		ServletContextHandler contextHandler = new ServletContextHandler(this.jettyServer, "", false, false);
+		contextHandler.addServlet(servletHolder, "/");
+
+		ServerConnector connector = new ServerConnector(this.jettyServer);
+		connector.setHost(getHost());
+		connector.setPort(getPort());
+		this.jettyServer.addConnector(connector);
 	}
-
 
 	@Override
 	public void start() {
 		if (!this.running) {
 			try {
 				this.running = true;
-				this.tomcatServer.start();
+				this.jettyServer.start();
 			}
-			catch (LifecycleException ex) {
+			catch (Exception ex) {
 				throw new IllegalStateException(ex);
 			}
 		}
@@ -91,10 +77,10 @@ public class TomcatHttpServer extends HttpServerSupport implements InitializingB
 		if (this.running) {
 			try {
 				this.running = false;
-				this.tomcatServer.stop();
-				this.tomcatServer.destroy();
+				jettyServer.stop();
+				jettyServer.destroy();
 			}
-			catch (LifecycleException ex) {
+			catch (Exception ex) {
 				throw new IllegalStateException(ex);
 			}
 		}

--- a/src/test/java/org/springframework/http/server/reactive/bootstrap/ReactorHttpServer.java
+++ b/src/test/java/org/springframework/http/server/reactive/bootstrap/ReactorHttpServer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.http.server.reactive.boot;
+package org.springframework.http.server.reactive.bootstrap;
 
 import reactor.core.flow.Loopback;
 import reactor.core.state.Completable;

--- a/src/test/java/org/springframework/http/server/reactive/bootstrap/RxNettyHttpServer.java
+++ b/src/test/java/org/springframework/http/server/reactive/bootstrap/RxNettyHttpServer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.http.server.reactive.boot;
+package org.springframework.http.server.reactive.bootstrap;
 
 import java.net.InetSocketAddress;
 

--- a/src/test/java/org/springframework/http/server/reactive/bootstrap/UndertowHttpServer.java
+++ b/src/test/java/org/springframework/http/server/reactive/bootstrap/UndertowHttpServer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.http.server.reactive.boot;
+package org.springframework.http.server.reactive.bootstrap;
 
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;

--- a/src/test/java/org/springframework/http/server/reactive/bootstrap/package-info.java
+++ b/src/test/java/org/springframework/http/server/reactive/bootstrap/package-info.java
@@ -2,4 +2,4 @@
  * This package contains temporary interfaces and classes for running embedded servers.
  * They are expected to be replaced by an upcoming Spring Boot support.
  */
-package org.springframework.http.server.reactive.boot;
+package org.springframework.http.server.reactive.bootstrap;


### PR DESCRIPTION
I think we discussed this a few times:

* moving those classes to test sources since we don't intend to
provide those to spring developers
* changing the `boot` part of the package name to avoid mixing
those with Spring Boot

WDYT?